### PR TITLE
Fix process id analyze error when same process bind to multiple entities

### DIFF
--- a/pkg/process/finders/storage.go
+++ b/pkg/process/finders/storage.go
@@ -164,17 +164,17 @@ func (s *ProcessStorage) processesReport(waitReportProcesses []*ProcessContext) 
 		return err
 	}
 
-	processIdBeenUsed := make(map[string]bool)
+	processIDBeenUsed := make(map[string]bool)
 	for _, waitProcess := range waitReportProcesses {
 		found := false
 		for _, reportedProcess := range processes.GetProcesses() {
 			id := s.finders[waitProcess.DetectType()].ParseProcessID(waitProcess.detectProcess, reportedProcess)
-			if id == "" || processIdBeenUsed[id] {
+			if id == "" || processIDBeenUsed[id] {
 				continue
 			}
 
 			s.updateProcessToUploadSuccess(waitProcess, id)
-			processIdBeenUsed[id] = true
+			processIDBeenUsed[id] = true
 			found = true
 			break
 		}

--- a/pkg/process/finders/storage.go
+++ b/pkg/process/finders/storage.go
@@ -164,15 +164,17 @@ func (s *ProcessStorage) processesReport(waitReportProcesses []*ProcessContext) 
 		return err
 	}
 
+	processIdBeenUsed := make(map[string]bool)
 	for _, waitProcess := range waitReportProcesses {
 		found := false
 		for _, reportedProcess := range processes.GetProcesses() {
 			id := s.finders[waitProcess.DetectType()].ParseProcessID(waitProcess.detectProcess, reportedProcess)
-			if id == "" {
+			if id == "" || processIdBeenUsed[id] {
 				continue
 			}
 
 			s.updateProcessToUploadSuccess(waitProcess, id)
+			processIdBeenUsed[id] = true
 			found = true
 			break
 		}

--- a/test/e2e/base/base-compose.yml
+++ b/test/e2e/base/base-compose.yml
@@ -17,7 +17,7 @@ version: '2.1'
 
 services:
   oap:
-    image: ghcr.io/apache/skywalking/oap:latest
+    image: ghcr.io/apache/skywalking/oap:a3e14bdc7adddd940f23b394672c4b685e6737fe
     expose:
       - 11800
       - 12800

--- a/test/e2e/cases/process/istio/e2e.yaml
+++ b/test/e2e/cases/process/istio/e2e.yaml
@@ -54,8 +54,8 @@ setup:
                        --set elasticsearch.imageTag=7.5.1 \
                        --set oap.replicas=1 \
                        --set ui.image.repository=ghcr.io/apache/skywalking/ui \
-                       --set ui.image.tag=latest \
-                       --set oap.image.tag=latest \
+                       --set ui.image.tag=a3e14bdc7adddd940f23b394672c4b685e6737fe \
+                       --set oap.image.tag=a3e14bdc7adddd940f23b394672c4b685e6737fe \
                        --set oap.image.repository=ghcr.io/apache/skywalking/oap \
                        --set oap.storageType=elasticsearch
       wait:


### PR DESCRIPTION
When a process has multiple entities, such as in the Kubernetes detector, the process may belong to MESH and K8S_SERVICE.
Currently, the rover only matches the **first** process ID to process. When profiling the process, it will not match the process.