### PR TITLE
Fix the profiling data finished time is greater than task duration

### DIFF
--- a/pkg/profiling/task/manager.go
+++ b/pkg/profiling/task/manager.go
@@ -234,6 +234,7 @@ func (m *Manager) flushProfilingData() error {
 			continue
 		}
 
+		currentMilli = m.minInt64(currentMilli, t.startRunningTime.UnixMilli()+t.task.MaxRunningDuration.Milliseconds())
 		// only the first data have task metadata
 		data[0].Task = &profiling_v3.EBPFProfilingTaskMetadata{
 			TaskId:             t.task.TaskID,
@@ -252,4 +253,11 @@ func (m *Manager) flushProfilingData() error {
 
 	_, err = stream.CloseAndRecv()
 	return err
+}
+
+func (m *Manager) minInt64(x, y int64) int64 {
+	if x > y {
+		return y
+	}
+	return x
 }


### PR DESCRIPTION
The rover uses the scratch mechanism to get data from the eBPF runner with intervals, but the profiling task duration is fixed. So the end time of the profiling data could be out of the profiling task duration. 
When the duration of the profiling task is the same as the time that OAP can analyze, it may cause the failure to analyze.