### PR TITLE
Fix profiling issue and add logs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,10 @@ Release Notes.
 * Support `OFF_CPU` Profiling.
 * Introduce the `BTFHub` module.
 * Update to using frequency mode to `ON_CPU` Profiling.
+* Add logs in the profiling module logical.
 
 #### Bug Fixes
+* Fix `docker` based process could not be detected.
 
 #### Issues and PR
 - All issues are [here](https://github.com/apache/skywalking/milestone/134?closed=1)

--- a/pkg/process/finders/kubernetes/container.go
+++ b/pkg/process/finders/kubernetes/container.go
@@ -69,6 +69,7 @@ func (c *PodContainer) CGroupID() string {
 	// delete the container runtime prefix is the cgroupid
 	cgroupID = strings.TrimPrefix(cgroupID, "containerd://")
 	cgroupID = strings.TrimPrefix(cgroupID, "dockerd://")
+	cgroupID = strings.TrimPrefix(cgroupID, "docker://")
 	return cgroupID
 }
 

--- a/pkg/profiling/task/oncpu/runner.go
+++ b/pkg/profiling/task/oncpu/runner.go
@@ -197,6 +197,8 @@ func (r *Runner) Stop() error {
 				result = multierror.Append(result, err)
 			}
 		}
+
+		close(r.stopChan)
 	})
 	return result
 }


### PR DESCRIPTION
1. Add logs in the profiling module to help understand the profiling status.
2. Fix the problem that `docker` based processes cannot be detected.
3. Fix can't do `ON_CPU` profiling twice error, It's a bug in the current milestone, so don't need to add it to the change log. 