### PR TITLE
Fixed reading process paths incorrect when running as a container

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Release Notes.
 * Let the logger as a configurable module.
 
 #### Bug Fixes
+* Fixed reading process paths incorrect when running as a container.
 
 #### Issues and PR
 - All issues are [here](https://github.com/apache/skywalking/milestone/144?closed=1)

--- a/pkg/tools/host/file.go
+++ b/pkg/tools/host/file.go
@@ -22,7 +22,15 @@ import (
 	"strings"
 )
 
-var hostMappingPath = os.Getenv("ROVER_HOST_MAPPING")
+var hostMappingPath string
+
+func init() {
+	hostMappingPath = os.Getenv("ROVER_HOST_MAPPING")
+	// adapt with gopsutil framework to read the right process directory of host
+	if hostMappingPath != "" {
+		os.Setenv("HOST_PROC", hostMappingPath+"/proc")
+	}
+}
 
 // GetFileInHost means add the host root mapping prefix, it's dependent when the rover is deploy in a container
 func GetFileInHost(absPath string) string {


### PR DESCRIPTION
The problem occurs when the rover is running in a docker-in-docker environment(like `kind`) because its privileged mode reads information from the docker, not from the host. 
So when the rover reads the process information in the container, it must be exactly according to "ROVER_HOST_MAPPING".