### PR TITLE
Fixed submitting multiple network profiling tasks with the same uri causing the rover to restart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Release Notes.
 * Enhance the protocol reader for support long socket data.
 
 #### Bug Fixes
+* Fixed submitting multiple network profiling tasks with the same uri causing the rover to restart
 
 #### Documentation
 

--- a/pkg/profiling/task/network/analyze/layer7/protocols/http1/sampling.go
+++ b/pkg/profiling/task/network/analyze/layer7/protocols/http1/sampling.go
@@ -192,7 +192,7 @@ func (s *SamplingConfig) findMatchesRule(uri string) *profiling.NetworkSamplingR
 			continue
 		}
 		result = rule.Rule
-		s.uriRuleCache.Add(uri, rule)
+		s.uriRuleCache.Add(uri, result)
 	}
 	return result
 }


### PR DESCRIPTION
…ausing the rover to restart
```
panic: interface conversion: interface {} is *http1.URISampling, not *base.NetworkSamplingRule

goroutine 108 [running]:
github.com/apache/skywalking-rover/pkg/profiling/task/network/analyze/layer7/protocols/http1.(*SamplingConfig).findMatchesRule(0xc001744120, {0xc0151f6584, 0xc})
        /src/pkg/profiling/task/network/analyze/layer7/protocols/http1/sampling.go:189 +0xeb
github.com/apache/skywalking-rover/pkg/profiling/task/network/analyze/layer7/protocols/http1.(*Sampler).AppendMetrics(0xc0003aad98, 0xc001744120, 0x31e9359, 0xc014f2c100, 0xc00189a480, {0x1ba2e30?, 0xc0152a2900}, {0x1ba2dd0?, 0xc0183d88a0})
        /src/pkg/profiling/task/network/analyze/layer7/protocols/http1/sampling.go:78 +0x1a5
github.com/apache/skywalking-rover/pkg/profiling/task/network/analyze/layer7/protocols/http1.(*URIMetrics).Append(0xc00008cf00, 0xc014f2c100?, 0x5?, {0x1ba2e30, 0xc0152a2900}, 0xc00189a480, {0x1ba2dd0, 0xc0183d88a0})
        /src/pkg/profiling/task/network/analyze/layer7/protocols/http1/metrics.go:103 +0x3c8
github.com/apache/skywalking-rover/pkg/profiling/task/network/analyze/layer7/protocols/http1.(*Analyzer).analyze(0xc000413db0, {0x1b?, 0xc015393d90?}, {0xc0151f6540, 0x1b}, 0xc018942d80, {0x1ba2e30, 0xc0152a2900}, {0x1ba2dd0, 0xc0183d88a0})
        /src/pkg/profiling/task/network/analyze/layer7/protocols/http1/analyzer.go:281 +0xb37
github.com/apache/skywalking-rover/pkg/profiling/task/network/analyze/layer7/protocols/http1.(*Analyzer).ReceiveData(0xc000413db0, {0x1b8ce68, 0xc001634080}, 0xc0152a7b00)
        /src/pkg/profiling/task/network/analyze/layer7/protocols/http1/analyzer.go:131 +0x533
github.com/apache/skywalking-rover/pkg/profiling/task/network/analyze/layer7/protocols.(*Analyzer).ReceiveSocketDataEvent(0xc001744150, 0xc0152a7b00)
        /src/pkg/profiling/task/network/analyze/layer7/protocols/protocols.go:64 +0x2ad
github.com/apache/skywalking-rover/pkg/profiling/task/network/analyze/layer7.(*SocketDataPartitionContext).Consume(0xc015393f98?, {0x1836c20?, 0xc0152a7b00?})
        /src/pkg/profiling/task/network/analyze/layer7/events.go:66 +0x35
github.com/apache/skywalking-rover/pkg/profiling/task/network/analyze/layer7.(*EventQueue).start0.func2(0xc000416580?)
        /src/pkg/profiling/task/network/analyze/layer7/queue.go:81 +0x7b
created by github.com/apache/skywalking-rover/pkg/profiling/task/network/analyze/layer7.(*EventQueue).start0
        /src/pkg/profiling/task/network/analyze/layer7/queue.go:75 +0x13c
```