### PR TITLE
Improve the performance when getting `goid` in eBPF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Release Notes.
 * Support OpenSSL 3.0.x.
 * Optimized the data structure in BPF.
 * Support continuous profiling.
+* Improve the performance when getting `goid` in eBPF.
 
 #### Bug Fixes
 * Fix HTTP method name in protocol analyzer

--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -45,4 +45,14 @@ typedef enum
 {
     true=1, false=0
 } bool;
+
+struct thread_struct {
+	long unsigned int fsbase;
+}   __attribute__((preserve_access_index));
+
+struct task_struct {
+	__u32 pid;
+    __u32 tgid;
+    struct thread_struct thread;
+}  __attribute__((preserve_access_index));
 #endif

--- a/bpf/include/symbol_offsets.h
+++ b/bpf/include/symbol_offsets.h
@@ -84,10 +84,6 @@ struct go_tls_args_symaddr_t {
     __u64 tcp_conn_offset;
     __u64 is_client_offset;
 
-    // casg
-    struct go_tls_arg_location_t casg_status_gp_loc;
-    struct go_tls_arg_location_t casg_status_new_val_loc;
-
     // read
     struct go_tls_arg_location_t read_connection_loc;
     struct go_tls_arg_location_t read_buffer_loc;

--- a/bpf/profiling/continuous/go_tls.c
+++ b/bpf/profiling/continuous/go_tls.c
@@ -16,7 +16,7 @@
 // under the License.
 
 #include "go_tls.h"
-#include "goid.c"
+#include "goid.h"
 
 SEC("uprobe/go_tls_write")
 int go_tls_write(struct pt_regs* ctx) {

--- a/bpf/profiling/network/go_tls.c
+++ b/bpf/profiling/network/go_tls.c
@@ -16,7 +16,7 @@
 // under the License.
 
 #include "go_tls.h"
-#include "goid.c"
+#include "goid.h"
 
 SEC("uprobe/go_tls_write")
 int go_tls_write(struct pt_regs* ctx) {

--- a/bpf/profiling/offcpu.h
+++ b/bpf/profiling/offcpu.h
@@ -45,8 +45,3 @@ struct {
 	__type(value, struct value_t);
 	__uint(max_entries, 10000);
 } counts SEC(".maps");
-
-struct task_struct {
-	__u32 pid;
-    __u32 tgid;
-}  __attribute__((preserve_access_index));

--- a/pkg/profiling/continuous/checker/bpf/network/ssl.go
+++ b/pkg/profiling/continuous/checker/bpf/network/ssl.go
@@ -29,7 +29,7 @@ func addSSLProcess(pid int, linker *btf.Linker, bpf *bpfObjects) error {
 
 	register.Envoy(bpf.EnvoyTlsArgsSymaddrMap, bpf.OpensslWrite, bpf.OpensslWriteRet, bpf.OpensslRead, bpf.OpensslReadRet)
 
-	register.GoTLS(bpf.GoTlsArgsSymaddrMap, bpf.GoCasgstatus, bpf.GoTlsWrite, bpf.GoTlsWriteRet, bpf.GoTlsRead, bpf.GoTlsReadRet)
+	register.GoTLS(bpf.GoTlsArgsSymaddrMap, bpf.GoTlsWrite, bpf.GoTlsWriteRet, bpf.GoTlsRead, bpf.GoTlsReadRet)
 
 	register.Node(bpf.OpensslSymaddrMap, nil, bpf.OpensslWrite, bpf.OpensslWriteRet, bpf.OpensslRead, bpf.OpensslReadRet,
 		nil, nil, nil)

--- a/pkg/profiling/task/network/ssl.go
+++ b/pkg/profiling/task/network/ssl.go
@@ -29,7 +29,7 @@ func addSSLProcess(pid int, loader *bpf.Loader) error {
 
 	register.Envoy(nil, loader.OpensslWrite, loader.OpensslWriteRet, loader.OpensslRead, loader.OpensslReadRet)
 
-	register.GoTLS(loader.GoTlsArgsSymaddrMap, loader.GoCasgstatus, loader.GoTlsWrite, loader.GoTlsWriteRet, loader.GoTlsRead, loader.GoTlsReadRet)
+	register.GoTLS(loader.GoTlsArgsSymaddrMap, loader.GoTlsWrite, loader.GoTlsWriteRet, loader.GoTlsRead, loader.GoTlsReadRet)
 
 	register.Node(nil, loader.NodeTlsSymaddrMap, loader.OpensslWrite, loader.OpensslWriteRet, loader.OpensslRead, loader.OpensslReadRet,
 		loader.NodeTlsRetSsl, loader.NodeTlsWrap, loader.NodeTlsWrapRet)


### PR DESCRIPTION
Inspired by pixie, we can no longer use `runtime.casgstatus` to get `goid`. Instead, get it directly from the local storage of the current thread.