### PR TITLE
Remove tmp path when building docker

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -45,4 +45,4 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push docker images
-        run: make docker docker.push
+        run: make docker.push

--- a/scripts/build/bash/btfgen.sh
+++ b/scripts/build/bash/btfgen.sh
@@ -48,3 +48,6 @@ each_all_bpf_so_file() {
 ${TMPDIR}/btfhub/tools/btfgen.sh -a ${ARCH} $(each_all_bpf_so_file $FROM)
 mkdir -p ${OUTPUT}
 cp -r ${TMPDIR}/btfhub/custom-archive/* ${OUTPUT}
+
+# remove the btfhub for save the space
+rm -rf $TMPDIR/btfhub


### PR DESCRIPTION
Following https://github.com/apache/skywalking-rover/actions/runs/5255995428/jobs/9509747351, the temporary build directory needs to be deleted when building the docker image on GHA to reduce the disk space.  