### PR TITLE
Resolve the insufficient space error while pushing Docker images with GitHub Action

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -44,5 +44,11 @@ jobs:
           registry: ${{ env.HUB }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Clean spaces for docker images
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Build and push docker images
         run: make docker.push


### PR DESCRIPTION
Following https://github.com/apache/skywalking-rover/actions/runs/6594862069, I encountered a space issue during the docker image push. Therefore, this PR attempts to clear space before pushing the image.