### PR TITLE
Support overwire the cluster name by user defined

### DIFF
--- a/pkg/process/finders/kubernetes/finder.go
+++ b/pkg/process/finders/kubernetes/finder.go
@@ -250,7 +250,7 @@ func (f *ProcessFinder) buildProcesses(p *process.Process, pc *PodContainer) ([]
 			return nil, err
 		}
 		// adding the cluster name into the service name
-		if f.clusterName != "" {
+		if f.clusterName != "" && !strings.Contains(entity.ServiceName, "::") {
 			entity.ServiceName = fmt.Sprintf("%s::%s", f.clusterName, entity.ServiceName)
 		}
 		processes = append(processes, NewProcess(p, cmdline, pc, entity))


### PR DESCRIPTION
If the service name already contains the cluster name, then ignore to adding them into the service name. 