### PR TITLE
Fix errors when compiling C source files into eBPF bytecode.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Release Notes.
 
 #### Bug Fixes
 * Fixed the issue where `conntrack` could not find the Reply IP in the access log module.
+* Fix errors when compiling C source files into eBPF bytecode on a system with Linux headers version 6.2 or higher.
 
 #### Documentation
 

--- a/bpf/accesslog/l24/read_l3.c
+++ b/bpf/accesslog/l24/read_l3.c
@@ -43,7 +43,7 @@ struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 10000);
 	__type(key, __u64);
-	__type(value, struct bpf_list_head);
+	__type(value, struct c_bpf_list_head);
 } ip_list_rcv_args_map SEC(".maps");
 
 #define ip_list_foreach_skb(loc, time)                                      \
@@ -74,7 +74,7 @@ int ip_list_rcv(struct pt_regs * ctx) {
     struct skb_receive_detail *detail = NULL;
 
     struct sk_buff *skb = NULL, *next = NULL;
-    struct bpf_list_head skb_list = init_bpf_list_head();
+    struct c_bpf_list_head skb_list = init_bpf_list_head();
     list_for_each_entry_init()
     ip_list_foreach_skb(enter_ip_rcv_time, enter_rcv_time)
     ip_list_foreach_skb(enter_ip_rcv_time, enter_rcv_time)
@@ -95,7 +95,7 @@ int ip_list_rcv(struct pt_regs * ctx) {
 SEC("kretprobe/ip_list_rcv")
 int ip_list_rcv_ret(struct pt_regs * ctx) {
     __u64 id = bpf_get_current_pid_tgid();
-    struct bpf_list_head *head = bpf_map_lookup_elem(&ip_list_rcv_args_map, &id);
+    struct c_bpf_list_head *head = bpf_map_lookup_elem(&ip_list_rcv_args_map, &id);
     if (head == NULL) {
         return 0;
     }
@@ -139,7 +139,7 @@ int ip_sublist_rcv_finish(struct pt_regs * ctx) {
     struct skb_receive_detail *detail = NULL;
 
     struct sk_buff *skb = NULL, *next = NULL;
-    struct bpf_list_head skb_list = init_bpf_list_head();
+    struct c_bpf_list_head skb_list = init_bpf_list_head();
     list_for_each_entry_init()
     ip_list_foreach_skb(ip_rcv_finish_time, rcv_finish_time)
     ip_list_foreach_skb(ip_rcv_finish_time, rcv_finish_time)

--- a/bpf/include/list.h
+++ b/bpf/include/list.h
@@ -62,32 +62,32 @@
     if (list_should_enter)
 
 // Customized BPF List implementation
-struct bpf_list_head {
+struct c_bpf_list_head {
     void *data;
-	struct bpf_list_head *next;
+	struct c_bpf_list_head *next;
 };
 
-static inline struct bpf_list_head init_bpf_list_head() {
-    struct bpf_list_head head = {};
+static inline struct c_bpf_list_head init_bpf_list_head() {
+    struct c_bpf_list_head head = {};
     head.data = NULL;
     head.next = NULL;
     return head;
 }
 
-static inline struct bpf_list_head append_bpf_list_head(struct bpf_list_head* head, void *data) {
-    struct bpf_list_head new_head = init_bpf_list_head();
+static inline struct c_bpf_list_head append_bpf_list_head(struct c_bpf_list_head* head, void *data) {
+    struct c_bpf_list_head new_head = init_bpf_list_head();
     new_head.data = data;
     new_head.next = head;
     return new_head;
 }
 
-static inline int bpf_list_empty(struct bpf_list_head *head) {
+static inline int bpf_list_empty(struct c_bpf_list_head *head) {
 	return head->next == NULL;
 }
 
 #define bpf_list_for_each_init()			\
     bool bpf_list_is_first = true;          \
-    struct bpf_list_head *current_node = NULL;
+    struct c_bpf_list_head *current_node = NULL;
 
 #define bpf_list_for_each_foreach(pos, head)			\
     if (bpf_list_is_first) {                                \


### PR DESCRIPTION
When I execute `make generate` on my system with Linux headers version 6.2 or higher, I got the following error:
```
skywalking-rover/bpf/include/list.h:65:8: error: redefinition of 'bpf_list_head'
   65 | struct bpf_list_head {
      |        ^
/usr/include/linux/bpf.h:7136:8: note: previous definition is here
 7136 | struct bpf_list_head {
      |        ^
```
I followed @mrproliu advice to add a prefix for bpf_list_head struct, it generate go file successfuly, I tested it in my local, it works well, Thanks for your help @mrproliu .
![image](https://github.com/apache/skywalking-rover/assets/16346644/551b4170-956e-40f8-984d-0d2309c5ec3e)

