### PR TITLE
Fixed `ip_list_rcv` probe is not exist in older linux kernel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Release Notes.
 #### Bug Fixes
 * Fixed the issue where `conntrack` could not find the Reply IP in the access log module.
 * Fix errors when compiling C source files into eBPF bytecode on a system with Linux headers version 6.2 or higher.
+* Fixed `ip_list_rcv` probe is not exist in older linux kernel.
 
 #### Documentation
 

--- a/pkg/accesslog/collector/l24.go
+++ b/pkg/accesslog/collector/l24.go
@@ -45,13 +45,13 @@ func (c *L24Collector) startRead(_ *module.Manager, context *common.AccessLogCon
 	context.BPF.AddTracePoint("net", "netif_receive_skb", context.BPF.TracepointNetifReceiveSkb)
 
 	// l3
-	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"ip_list_rcv": context.BPF.IpListRcv})
-	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{"ip_list_rcv": context.BPF.IpListRcvRet})
 	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"ip_rcv": context.BPF.IpRcv})
 	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{"ip_rcv": context.BPF.IpRcvRet})
 	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"ip_rcv_finish": context.BPF.IpRcvFinish})
 	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"ip_local_deliver": context.BPF.IpLocalDeliver})
 	// it's not exist in old kernel versions
+	_ = context.BPF.AddLinkOrError(link.Kprobe, map[string]*ebpf.Program{"ip_list_rcv": context.BPF.IpListRcv})
+	_ = context.BPF.AddLinkOrError(link.Kretprobe, map[string]*ebpf.Program{"ip_list_rcv": context.BPF.IpListRcvRet})
 	_ = context.BPF.AddLinkOrError(link.Kprobe, map[string]*ebpf.Program{"ip_sublist_rcv_finish": context.BPF.IpSublistRcvFinish})
 	_ = context.BPF.AddLinkOrError(link.Kprobe, map[string]*ebpf.Program{"ip_local_deliver_finish": context.BPF.IpLocalDeliverFinish})
 


### PR DESCRIPTION
Following https://github.com/apache/skywalking/issues/12324 and https://github.com/torvalds/linux/blob/v4.18/net/ipv4/ip_input.c, It appears that `ip_list_rcv` does not exist in older kernel versions.