### PR TITLE
Fix concurrent map operation in the access log module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Release Notes.
 * Fixed the issue where `conntrack` could not find the Reply IP in the access log module.
 * Fix errors when compiling C source files into eBPF bytecode on a system with Linux headers version 6.2 or higher.
 * Fixed `ip_list_rcv` probe is not exist in older linux kernel.
+* Fix concurrent map operation in the access log module.
 
 #### Documentation
 

--- a/pkg/accesslog/common/connection.go
+++ b/pkg/accesslog/common/connection.go
@@ -447,6 +447,8 @@ func (c *ConnectionManager) AddNewProcess(pid int32, entities []api.ProcessInter
 }
 
 func (c *ConnectionManager) rebuildLocalIPWithPID() {
+	c.monitoringProcessLock.RLock()
+	defer c.monitoringProcessLock.RUnlock()
 	result := make(map[string]int32)
 	for pid, entities := range c.monitoringProcesses {
 		for _, entity := range entities {
@@ -575,7 +577,7 @@ func (c *ConnectionManager) OnBuildConnectionLogFinished() {
 			return
 		}
 		// already mark as deletable or process not monitoring
-		shouldDelete := con.MarkDeletable || len(c.monitoringProcesses[int32(con.PID)]) == 0
+		shouldDelete := con.MarkDeletable || !c.ProcessIsMonitor(con.PID)
 
 		if shouldDelete {
 			deletableConnections = append(deletableConnections, key)

--- a/pkg/accesslog/common/connection.go
+++ b/pkg/accesslog/common/connection.go
@@ -447,8 +447,6 @@ func (c *ConnectionManager) AddNewProcess(pid int32, entities []api.ProcessInter
 }
 
 func (c *ConnectionManager) rebuildLocalIPWithPID() {
-	c.monitoringProcessLock.RLock()
-	defer c.monitoringProcessLock.RUnlock()
 	result := make(map[string]int32)
 	for pid, entities := range c.monitoringProcesses {
 		for _, entity := range entities {
@@ -527,6 +525,8 @@ func (c *ConnectionManager) RecheckAllProcesses(processes map[int32][]api.Proces
 		processInBPF[int32(pid)] = true
 	}
 
+	c.monitoringProcessLock.RLock()
+	defer c.monitoringProcessLock.RUnlock()
 	// make sure BPF and user space are consistent
 	for pid := range processInBPF {
 		if _, ok := c.monitoringProcesses[pid]; !ok {


### PR DESCRIPTION
Sometimes rover execution is terminated because multiple goroutines operate on the same map. This PR will fix this problem.
![image](https://github.com/apache/skywalking-rover/assets/3417650/e6c7d746-8309-4fe7-be6e-e71a91dd6906)
