### PR TITLE
Fix some connections not called close syscall, causing unnecessary memory usage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Release Notes.
 * Fix the profiling cannot found process issue.
 * Fix cannot translate peer address in some UDP scenarios.
 * Fix the protocol logs may be missing if the process is short-lived.
+* Fix some connections not called close syscall, causing unnecessary memory usage.
 
 #### Documentation
 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -26,6 +26,7 @@ RUN apt update && \
     cd bpftool && make -C src install && cp $(which bpftool) /usr/sbin/bpftool && \
     wget https://apt.llvm.org/llvm.sh && \
     chmod +x llvm.sh && \
-    ./llvm.sh 18
+    ./llvm.sh 18 && \
+    apt install -y llvm-18
 
 ENV PATH="${PATH}:/usr/lib/llvm-18/bin"

--- a/pkg/accesslog/common/connection.go
+++ b/pkg/accesslog/common/connection.go
@@ -426,8 +426,8 @@ func (c *ConnectionManager) savingTheAddress(host string, port uint16, localPid 
 	log.Debugf("saving the %s address with pid cache, address: %s:%d, pid: %d", localStr, host, port, pid)
 }
 
-func (c *ConnectionManager) getAddressPid(host string, port uint16, localPid bool) *addressInfo {
-	addrInfo, ok := c.addressWithPid.Get(fmt.Sprintf("%s_%d_%t", host, port, localPid))
+func (c *ConnectionManager) getAddressPid(hostAddress string, port uint16, localPid bool) *addressInfo {
+	addrInfo, ok := c.addressWithPid.Get(fmt.Sprintf("%s_%d_%t", hostAddress, port, localPid))
 	if ok && addrInfo != nil {
 		return addrInfo.(*addressInfo)
 	}

--- a/pkg/accesslog/common/connection.go
+++ b/pkg/accesslog/common/connection.go
@@ -414,16 +414,16 @@ func (c *ConnectionManager) OnConnectionClose(event *events.SocketCloseEvent) *C
 	return result
 }
 
-func (c *ConnectionManager) savingTheAddress(host string, port uint16, localPid bool, pid uint32) {
+func (c *ConnectionManager) savingTheAddress(hostAddress string, port uint16, localPid bool, pid uint32) {
 	localAddrInfo := &addressInfo{
 		pid: pid,
 	}
-	c.addressWithPid.Set(fmt.Sprintf("%s_%d_%t", host, port, localPid), localAddrInfo, localAddressPairCacheTime)
+	c.addressWithPid.Set(fmt.Sprintf("%s_%d_%t", hostAddress, port, localPid), localAddrInfo, localAddressPairCacheTime)
 	localStr := strRemote
 	if localPid {
 		localStr = strLocal
 	}
-	log.Debugf("saving the %s address with pid cache, address: %s:%d, pid: %d", localStr, host, port, pid)
+	log.Debugf("saving the %s address with pid cache, address: %s:%d, pid: %d", localStr, hostAddress, port, pid)
 }
 
 func (c *ConnectionManager) getAddressPid(hostAddress string, port uint16, localPid bool) *addressInfo {

--- a/pkg/accesslog/forwarder/close.go
+++ b/pkg/accesslog/forwarder/close.go
@@ -34,6 +34,9 @@ func SendCloseEvent(context *common.AccessLogContext, event *common.CloseEventWi
 
 func closeLogBuilder(event events.Event) *v3.AccessLogKernelLog {
 	closeEvent := event.(*common.CloseEventWithNotify)
+	if closeEvent.StartTime == 0 {
+		return nil
+	}
 	closeOp := &v3.AccessLogKernelCloseOperation{}
 	closeOp.StartTime = BuildOffsetTimestamp(closeEvent.StartTime)
 	closeOp.EndTime = BuildOffsetTimestamp(closeEvent.EndTime)

--- a/pkg/accesslog/runner.go
+++ b/pkg/accesslog/runner.go
@@ -88,7 +88,7 @@ func (r *Runner) Start(ctx context.Context) error {
 	r.ctx = ctx
 	r.context.RuntimeContext = ctx
 	r.context.Queue.Start(ctx)
-	r.context.ConnectionMgr.Start()
+	r.context.ConnectionMgr.Start(ctx, r.context)
 	for _, c := range r.collectors {
 		err := c.Start(r.mgr, r.context)
 		if err != nil {


### PR DESCRIPTION
When the system runs for a long time due to excessive invalid Active Connections in BPF, it becomes unable to write new connection information. This PR introduces the interval cleanup policy to remove invalid Active Connections from BPF.