### PR TITLE
Add detect process from `CRI-O` container in Kubernetes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Release Notes.
 * Upgrade LLVM to `18`.
 * Support propagation the excluding namespaces in the access log to the backend.
 * Add `pprof` module for observe self.
+* Add detect process from `CRI-O` container in Kubernetes.
 
 #### Bug Fixes
 * Fixed the issue where `conntrack` could not find the Reply IP in the access log module.

--- a/pkg/process/finders/kubernetes/container.go
+++ b/pkg/process/finders/kubernetes/container.go
@@ -70,6 +70,7 @@ func (c *PodContainer) CGroupID() string {
 	cgroupID = strings.TrimPrefix(cgroupID, "containerd://")
 	cgroupID = strings.TrimPrefix(cgroupID, "dockerd://")
 	cgroupID = strings.TrimPrefix(cgroupID, "docker://")
+	cgroupID = strings.TrimPrefix(cgroupID, "cri-o://")
 	return cgroupID
 }
 

--- a/pkg/process/finders/kubernetes/finder.go
+++ b/pkg/process/finders/kubernetes/finder.go
@@ -50,7 +50,10 @@ import (
 
 var log = logger.GetLogger("process", "finder", "kubernetes")
 
-var kubepodsRegex = regexp.MustCompile(`cri-containerd-(?P<Group>\w+)\.scope`)
+var (
+	kubepodsRegex      = regexp.MustCompile(`cri-containerd-(?P<Group>\w+)\.scope`)
+	openShiftPodsRegex = regexp.MustCompile(`crio-(?P<Group>\w+)\.scope`)
+)
 
 type ProcessFinder struct {
 	conf *Config
@@ -288,6 +291,9 @@ func (f *ProcessFinder) getProcessCGroup(pid int32) ([]string, error) {
 			// ex: cri-containerd-7dae778c37bd1204677518f1032bbecf01f5c41878ea7bd370021263417cc626.scope
 			if kubepod := kubepodsRegex.FindStringSubmatch(path); len(kubepod) >= 1 {
 				path = kubepod[1]
+			}
+			if openShiftPod := openShiftPodsRegex.FindStringSubmatch(path); len(openShiftPod) >= 1 {
+				path = openShiftPod[1]
 			}
 			cache[path] = true
 		}


### PR DESCRIPTION
When I'm trying to deploy the skywalking rover in the OpenShift, the processes cannot be detected. Because the OpenShift uses the `CRI-O` container runtime as default. So, in this PR, I made the rover support to detect the `CRI-O` based process to fix the issue which cannot found any process. 