### PR TITLE
Remove unnecessary generic parameters

### DIFF
--- a/pkg/profiling/continuous/checker/common/http_checker.go
+++ b/pkg/profiling/continuous/checker/common/http_checker.go
@@ -28,7 +28,7 @@ import (
 	v3 "skywalking.apache.org/repo/goapi/collect/ebpf/profiling/v3"
 )
 
-type HTTPBasedChecker[Data base.WindowData[network.BufferEvent, float64]] struct {
+type HTTPBasedChecker struct {
 	*BaseChecker[*HTTPBasedCheckerProcessInfo]
 
 	CheckType         base.CheckType
@@ -36,10 +36,10 @@ type HTTPBasedChecker[Data base.WindowData[network.BufferEvent, float64]] struct
 	ThresholdGenerate func(val string) (float64, error)
 }
 
-func NewHTTPBasedChecker[Data base.WindowData[network.BufferEvent, float64]](checkType base.CheckType,
+func NewHTTPBasedChecker(checkType base.CheckType,
 	thresholdGenerator func(val string) (float64, error), dataGenerator func() base.WindowData[network.BufferEvent, float64],
-	monitorType v3.ContinuousProfilingTriggeredMonitorType) *HTTPBasedChecker[Data] {
-	checker := &HTTPBasedChecker[Data]{
+	monitorType v3.ContinuousProfilingTriggeredMonitorType) *HTTPBasedChecker {
+	checker := &HTTPBasedChecker{
 		CheckType:         checkType,
 		ThresholdGenerate: thresholdGenerator,
 		MonitorType:       monitorType,
@@ -113,7 +113,7 @@ func NewHTTPBasedChecker[Data base.WindowData[network.BufferEvent, float64]](che
 	return checker
 }
 
-func (n *HTTPBasedChecker[Data]) SyncPolicies(policies []*base.SyncPolicyWithProcesses) {
+func (n *HTTPBasedChecker) SyncPolicies(policies []*base.SyncPolicyWithProcesses) {
 	n.BaseChecker.SyncPolicies(policies, func(items map[base.CheckType]*base.PolicyItem) *base.PolicyItem {
 		item := items[n.CheckType]
 		if item == nil {
@@ -142,7 +142,7 @@ func (n *HTTPBasedChecker[Data]) SyncPolicies(policies []*base.SyncPolicyWithPro
 	})
 }
 
-func (n *HTTPBasedChecker[Data]) ReceiveBufferEvent(event network.BufferEvent) {
+func (n *HTTPBasedChecker) ReceiveBufferEvent(event network.BufferEvent) {
 	info := n.PidWithInfos[event.Pid()]
 	if info == nil {
 		return
@@ -172,15 +172,15 @@ func (n *HTTPBasedChecker[Data]) ReceiveBufferEvent(event network.BufferEvent) {
 	}
 }
 
-func (n *HTTPBasedChecker[Data]) Fetch() error {
+func (n *HTTPBasedChecker) Fetch() error {
 	return nil
 }
 
-func (n *HTTPBasedChecker[Data]) Close() error {
+func (n *HTTPBasedChecker) Close() error {
 	return network.ForceShutdownBPF()
 }
 
-func (n *HTTPBasedChecker[Data]) Check(ctx base.CheckContext, metricsAppender *base.MetricsAppender) []base.ThresholdCause {
+func (n *HTTPBasedChecker) Check(ctx base.CheckContext, metricsAppender *base.MetricsAppender) []base.ThresholdCause {
 	causes := make([]base.ThresholdCause, 0)
 	for _, pidPolicies := range n.PidWithInfos {
 		for item, itemInfo := range pidPolicies.PolicyWithWindows {
@@ -220,7 +220,7 @@ func (n *HTTPBasedChecker[Data]) Check(ctx base.CheckContext, metricsAppender *b
 	return causes
 }
 
-func (n *HTTPBasedChecker[Data]) flushMetrics(uri string, windows *base.TimeWindows[network.BufferEvent, float64],
+func (n *HTTPBasedChecker) flushMetrics(uri string, windows *base.TimeWindows[network.BufferEvent, float64],
 	process api.ProcessInterface, metricsAppender *base.MetricsAppender) {
 	if uri == "" {
 		uri = "global"

--- a/pkg/profiling/continuous/checker/network_error_rate.go
+++ b/pkg/profiling/continuous/checker/network_error_rate.go
@@ -28,7 +28,7 @@ import (
 )
 
 type NetworkHTTPErrorRateChecker struct {
-	*common.HTTPBasedChecker[*processNetworkResponseErrorStatics]
+	*common.HTTPBasedChecker
 }
 
 func NewNetworkResponseErrorChecker() *NetworkHTTPErrorRateChecker {
@@ -36,7 +36,7 @@ func NewNetworkResponseErrorChecker() *NetworkHTTPErrorRateChecker {
 }
 
 func (n *NetworkHTTPErrorRateChecker) Init(config *base.ContinuousConfig) error {
-	n.HTTPBasedChecker = common.NewHTTPBasedChecker[*processNetworkResponseErrorStatics](
+	n.HTTPBasedChecker = common.NewHTTPBasedChecker(
 		base.CheckTypeHTTPErrorRate, func(val string) (float64, error) {
 			v, err := strconv.ParseFloat(val, 64)
 			if err != nil {

--- a/pkg/profiling/continuous/checker/network_response_time.go
+++ b/pkg/profiling/continuous/checker/network_response_time.go
@@ -28,7 +28,7 @@ import (
 )
 
 type NetworkHTTPAvgResponseTimeChecker struct {
-	*common.HTTPBasedChecker[*processNetworkAvgResponseTimeStatics]
+	*common.HTTPBasedChecker
 }
 
 func NewNetworkAvgResponseTimeChecker() *NetworkHTTPAvgResponseTimeChecker {
@@ -36,7 +36,7 @@ func NewNetworkAvgResponseTimeChecker() *NetworkHTTPAvgResponseTimeChecker {
 }
 
 func (n *NetworkHTTPAvgResponseTimeChecker) Init(config *base.ContinuousConfig) error {
-	n.HTTPBasedChecker = common.NewHTTPBasedChecker[*processNetworkAvgResponseTimeStatics](
+	n.HTTPBasedChecker = common.NewHTTPBasedChecker(
 		base.CheckTypeHTTPAvgResponseTime, func(val string) (float64, error) {
 			return strconv.ParseFloat(val, 64)
 		}, func() base.WindowData[network.BufferEvent, float64] {


### PR DESCRIPTION
These generic functions and generic structures are unnecessary and only make the code harder to read, so these generics have been removed.