### PR TITLE
Fix context structs parameters for tracepoint programs

### DIFF
--- a/bpf/accesslog/l24/read_l2.c
+++ b/bpf/accesslog/l24/read_l2.c
@@ -17,14 +17,15 @@
 
 #include "l24.h"
 #include "../common/data_args.h"
+#include "api.h"
 
-struct netif_receive_skb {
-	unsigned long long pad;
-	void * skbaddr;
-};
+struct trace_event_raw_net_dev_template {
+    struct trace_entry ent;
+    void *skbaddr;
+} __attribute__((preserve_access_index)) ;
 
 SEC("tracepoint/net/netif_receive_skb")
-int tracepoint_netif_receive_skb(struct netif_receive_skb *ctx) {
+int tracepoint_netif_receive_skb(struct trace_event_raw_net_dev_template *ctx) {
     struct sk_buff * skb = (struct sk_buff *)ctx->skbaddr;
 
     struct net_device *device = _(skb->dev);

--- a/bpf/accesslog/l24/write_l4.c
+++ b/bpf/accesslog/l24/write_l4.c
@@ -19,12 +19,11 @@
 #include "../common/data_args.h"
 #include "../common/sock.h"
 
-struct kfree_skb_args {
-  unsigned long pad;
-
-  void *skb;
-  void *location;
-};
+struct trace_event_raw_kfree_skb {
+    struct trace_entry ent;
+    void *skbaddr;
+    void *location;
+} __attribute__((preserve_access_index));
 
 SEC("kprobe/tcp_sendmsg")
 int tcp_sendmsg(struct pt_regs* ctx) {
@@ -83,8 +82,8 @@ int tracepoint_tcp_retransmit_skb() {
     }
 
 SEC("tracepoint/skb/kfree_skb")
-int kfree_skb(struct kfree_skb_args *args) {
-    struct sk_buff *skb = args->skb;
+int kfree_skb(struct trace_event_raw_kfree_skb *args) {
+    struct sk_buff *skb = (struct sk_buff *)args->skbaddr;
     if (skb == NULL) {
         return 0;
     }

--- a/bpf/accesslog/process/process.c
+++ b/bpf/accesslog/process/process.c
@@ -26,19 +26,17 @@ struct process_execute_event {
     __u32 pid;
 };
 
-struct sched_comm_fork_ctx {
-    unsigned short common_type;
-    unsigned char common_flags;
-    unsigned char common_preempt_count;
-    int common_pid;
-	char parent_comm[16];
-	pid_t parent_pid;
-	char child_comm[16];
-	pid_t child_pid;
-};
+struct trace_event_raw_sched_process_fork {
+        struct trace_entry ent;
+        char parent_comm[16];
+        __u32 parent_pid;
+        char child_comm[16];
+        __u32 child_pid;
+        char __data[0];
+}  __attribute__((preserve_access_index)) ;
 
 SEC("tracepoint/sched/sched_process_fork")
-int tracepoint_sched_process_fork(struct sched_comm_fork_ctx* ctx) {
+int tracepoint_sched_process_fork(struct trace_event_raw_sched_process_fork* ctx) {
     __u32 tgid = ctx->parent_pid;
     // adding to the monitor
     __u32 v = 1;

--- a/bpf/accesslog/syscalls/close.c
+++ b/bpf/accesslog/syscalls/close.c
@@ -21,19 +21,6 @@
 #include "../process/process.h"
 #include "../common/connection.h"
 
-struct trace_point_enter_close {
-    __u64 pad_0;
-    int __syscall_nr;
-    __u32 pad_1;
-    int fd;
-};
-struct trace_point_exit_close {
-    __u64 pad_0;
-    __u32 __syscall_nr;
-    __u32 pad_1;
-    __u64 ret;
-};
-
 static __inline void process_close_sock(void* ctx, __u64 id, struct sock_close_args_t *args, int ret) {
     __u32 tgid = (__u32)(id >> 32);
     if (args->fd < 0) {
@@ -44,25 +31,25 @@ static __inline void process_close_sock(void* ctx, __u64 id, struct sock_close_a
 }
 
 SEC("tracepoint/syscalls/sys_enter_close")
-int tracepoint_enter_close(struct trace_point_enter_close *ctx) {
+int tracepoint_enter_close(struct syscall_trace_enter *ctx) {
     uint64_t id = bpf_get_current_pid_tgid();
     if (tgid_should_trace(id >> 32) == false) {
         return 0;
     }
 
     struct sock_close_args_t close_args = {};
-    close_args.fd = ctx->fd;
+    close_args.fd = (__u32)ctx->args[0];
     close_args.start_nacs = bpf_ktime_get_ns();
     bpf_map_update_elem(&closing_args, &id, &close_args, 0);
 	return 0;
 }
 
 SEC("tracepoint/syscalls/sys_exit_close")
-int tracepoint_exit_close(struct trace_point_exit_close *ctx) {
+int tracepoint_exit_close(struct syscall_trace_exit *ctx) {
     __u64 id = bpf_get_current_pid_tgid();
     struct sock_close_args_t *close_args = bpf_map_lookup_elem(&closing_args, &id);
     if (close_args) {
-        process_close_sock(ctx, id, close_args, ctx->ret);
+        process_close_sock(ctx, id, close_args, (int)ctx->ret);
     }
 
     bpf_map_delete_elem(&closing_args, &id);

--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -46,6 +46,23 @@ typedef enum
     true=1, false=0
 } bool;
 
+struct trace_entry {
+        short unsigned int type;
+        unsigned char flags;
+        unsigned char preempt_count;
+        int pid;
+} __attribute__((preserve_access_index));
+struct syscall_trace_enter {
+        struct trace_entry ent;
+        int nr;
+        long unsigned int args[0];
+} __attribute__((preserve_access_index));
+struct syscall_trace_exit {
+    struct trace_entry ent;
+    int nr;
+    long int ret;
+}__attribute__((preserve_access_index));
+
 struct thread_struct {
     // x86_64
 	long unsigned int fsbase;


### PR DESCRIPTION
As mentioned in this issue (https://github.com/apache/skywalking/discussions/12779), modification were made to the input parameters of tracepoint programs to ensure compatibility with scenarios where kernel parameter sizes vary, preventing potential errors. The detailed modification infomation can be found at https://github.com/apache/skywalking/discussions/12779#discussioncomment-11322309.