### PR TITLE
Fix the unaligned memory accesses for upload_socket_data_buf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Release Notes.
 * Fix context structs parameters for tracepoint programs.
 * Improve the build of skywalking-rover by adding some options.
 * Decode the BPF data by self instant `binary.Read` to reduce CPU usage.
+* Fix the unaligned memory accesses for `upload_socket_data_buf`.
 
 #### Bug Fixes
 * Fix the base image cannot run in the arm64.

--- a/bpf/include/socket_opts.h
+++ b/bpf/include/socket_opts.h
@@ -43,7 +43,7 @@
 // for protocol analyze need to read
 #define MAX_PROTOCOL_SOCKET_READ_LENGTH 31
 // for transmit to the user space
-#define MAX_TRANSMIT_SOCKET_READ_LENGTH 2047
+#define MAX_TRANSMIT_SOCKET_READ_LENGTH 2048
 
 // unknown the connection type, not trigger the syscall connect,accept
 #define AF_UNKNOWN 0xff


### PR DESCRIPTION
As described in the [Fix the unaligned memory accesses for upload_socket_data_buf in skywalking-rover](https://github.com/apache/skywalking/issues/12830), Fix the unaligned memory accesses.