### PR TITLE
Fix missing the first socket detail event in HTTPS protocol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Release Notes.
 * Decode the BPF data by self instant `binary.Read` to reduce CPU usage.
 * Fix the unaligned memory accesses for `upload_socket_data_buf`.
 * Support for connecting to the backend server over TLS without requiring `ca.pem`.
+* Fix missing the first socket detail event in HTTPS protocol.
 
 #### Bug Fixes
 * Fix the base image cannot run in the arm64.

--- a/bpf/accesslog/syscalls/transfer.h
+++ b/bpf/accesslog/syscalls/transfer.h
@@ -143,7 +143,7 @@ static __always_inline void process_write_data(void *ctx, __u64 id, struct sock_
     // upload the socket detail, detail can only be send when the ssl are same:
     // 1. when the SSL connection sends SSL(unencrypted) message
     // 2. when the not SSL connection sends plain data
-    if (connection->ssl == ssl) {
+    if (conn->ssl == ssl) {
         __u32 kZero = 0;
         struct socket_detail_t *detail = bpf_map_lookup_elem(&socket_detail_event_per_cpu_map, &kZero);
         if (detail != NULL) {

--- a/bpf/accesslog/syscalls/transfer.h
+++ b/bpf/accesslog/syscalls/transfer.h
@@ -80,8 +80,9 @@ struct {
 
 
 static __inline void upload_socket_detail(void *ctx, __u64 conid, struct active_connection_t *connection, __u8 func_name, struct sock_data_args_t *data_args, bool ssl, __u64 end_nacs) {
-    // only send the original socket syscall(not ssl)
-    if (ssl == true) {
+    // 1. send when the SSL connection sends SSL(unencrypted) message
+    // 2. send the plain data when not SSL connection
+    if ((connection->ssl == true && ssl == true) || connection->ssl == false && ssl == false) {
         return;
     }
     __u32 kZero = 0;

--- a/bpf/accesslog/syscalls/transfer.h
+++ b/bpf/accesslog/syscalls/transfer.h
@@ -148,34 +148,34 @@ static __always_inline void process_write_data(void *ctx, __u64 id, struct sock_
         struct socket_detail_t *detail = bpf_map_lookup_elem(&socket_detail_event_per_cpu_map, &kZero);
         if (detail != NULL) {
             detail->connection_id = conid;
-            detail->random_id = connection->random_id;
-            detail->data_id = data_args->data_id;
+            detail->random_id = conn->random_id;
+            detail->data_id = args->data_id;
 
-            detail->start_nacs = data_args->start_nacs;
-            detail->end_nacs = end_nacs;
+            detail->start_nacs = args->start_nacs;
+            detail->end_nacs = curr_nacs;
 
-            detail->l4_duration = data_args->exit_l4_time - data_args->enter_l4_time;
-            detail->l3_duration = data_args->l3_duration;
-            detail->l3_local_duration = data_args->l3_local_duration;
-            detail->l3_output_duration = data_args->l3_output_duration;
-            detail->l3_resolve_mac_duration = data_args->total_resolve_mac_time;
-            detail->l3_net_filter_duration = data_args->total_net_filter_time;
-            detail->l2_duration = data_args->l2_duration;
-            detail->l2_ready_send_duration = data_args->l2_ready_send_duration;
-            detail->l2_send_duration = data_args->l2_send_duration;
-            detail->ifindex = data_args->ifindex;
-            detail->l4_total_package_size = data_args->total_package_size;
-            detail->l4_package_count = data_args->package_count;
-            detail->l4_retransmit_package_count = data_args->retransmit_package_count;
-            detail->l3_resolve_mac_count = data_args->total_resolve_mac_count;
-            detail->l3_net_filter_count = data_args->total_net_filter_count;
+            detail->l4_duration = args->exit_l4_time - args->enter_l4_time;
+            detail->l3_duration = args->l3_duration;
+            detail->l3_local_duration = args->l3_local_duration;
+            detail->l3_output_duration = args->l3_output_duration;
+            detail->l3_resolve_mac_duration = args->total_resolve_mac_time;
+            detail->l3_net_filter_duration = args->total_net_filter_time;
+            detail->l2_duration = args->l2_duration;
+            detail->l2_ready_send_duration = args->l2_ready_send_duration;
+            detail->l2_send_duration = args->l2_send_duration;
+            detail->ifindex = args->ifindex;
+            detail->l4_total_package_size = args->total_package_size;
+            detail->l4_package_count = args->package_count;
+            detail->l4_retransmit_package_count = args->retransmit_package_count;
+            detail->l3_resolve_mac_count = args->total_resolve_mac_count;
+            detail->l3_net_filter_count = args->total_net_filter_count;
             detail->op_func_name = func_name;
-            detail->data_protocol = connection->protocol;
-            detail->ssl = connection->ssl;
-            detail->l2_package_to_queue_time = data_args->total_package_to_queue_time;
-            detail->l3_total_recv_time = data_args->l3_rcv_duration;
-            detail->l2_enter_queue_count = data_args->l2_enter_queue_count;
-            detail->l4_package_rcv_from_queue_time = data_args->total_package_receive_from_queue_time;
+            detail->data_protocol = conn->protocol;
+            detail->ssl = conn->ssl;
+            detail->l2_package_to_queue_time = args->total_package_to_queue_time;
+            detail->l3_total_recv_time = args->l3_rcv_duration;
+            detail->l2_enter_queue_count = args->l2_enter_queue_count;
+            detail->l4_package_rcv_from_queue_time = args->total_package_receive_from_queue_time;
 
             bpf_perf_event_output(ctx, &socket_detail_data_queue, BPF_F_CURRENT_CPU, detail, sizeof(*detail));
         }

--- a/bpf/accesslog/syscalls/transfer.h
+++ b/bpf/accesslog/syscalls/transfer.h
@@ -80,9 +80,10 @@ struct {
 
 
 static __inline void upload_socket_detail(void *ctx, __u64 conid, struct active_connection_t *connection, __u8 func_name, struct sock_data_args_t *data_args, bool ssl, __u64 end_nacs) {
-    // 1. send when the SSL connection sends SSL(unencrypted) message
-    // 2. send the plain data when not SSL connection
-    if ((connection->ssl == true && ssl == true) || connection->ssl == false && ssl == false) {
+    // detail can only be send when the ssl are same:
+    // 1. when the SSL connection sends SSL(unencrypted) message
+    // 2. when the not SSL connection sends plain data
+    if (connection->ssl == ssl) {
         return;
     }
     __u32 kZero = 0;

--- a/bpf/accesslog/tls/go_tls.c
+++ b/bpf/accesslog/tls/go_tls.c
@@ -98,7 +98,7 @@ int go_tls_write_ret(struct pt_regs* ctx) {
         data_args.fd = args->fd;
         data_args.buf = args->buffer_ptr;
         data_args.start_nacs = args->start_nacs;
-        data_args.data_id = get_socket_data_id(6, id, fd);
+        data_args.data_id = get_socket_data_id(6, id, args->fd);
 
         process_write_data(ctx, id, &data_args, retval0, SOCK_DATA_DIRECTION_EGRESS, false, SOCKET_OPTS_TYPE_GOTLS_WRITE, true);
     }
@@ -186,7 +186,7 @@ int go_tls_read_ret(struct pt_regs* ctx) {
         data_args.fd = args->fd;
         data_args.buf = args->buffer_ptr;
         data_args.start_nacs = args->start_nacs;
-        data_args.data_id = get_socket_data_id(8, id, fd);
+        data_args.data_id = get_socket_data_id(8, id, args->fd);
 
         process_write_data(ctx, id, &data_args, retval0, SOCK_DATA_DIRECTION_INGRESS, false, SOCKET_OPTS_TYPE_GOTLS_WRITE, true);
     }

--- a/bpf/accesslog/tls/go_tls.h
+++ b/bpf/accesslog/tls/go_tls.h
@@ -25,6 +25,7 @@ struct go_tls_connection_args_t {
     void* connection_ptr;
     char* buffer_ptr;
     __u64 start_nacs;
+    __u32 fd;
 };
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);


### PR DESCRIPTION
Currently, since the first socket detail is sent based on protocol content during HTTPS parsing, the first socket detail data is treated as a non-protocol kernel event and cannot be associated with the protocol. 
This PR addresses this issue.