### PR TITLE
Support parallel parsing protocol data in the access log module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Release Notes.
 * Fix the unaligned memory accesses for `upload_socket_data_buf`.
 * Support for connecting to the backend server over TLS without requiring `ca.pem`.
 * Fix missing the first socket detail event in HTTPS protocol.
+* Support parallel parsing protocol data in the access log module.
 
 #### Bug Fixes
 * Fix the base image cannot run in the arm64.

--- a/configs/rover_configs.yaml
+++ b/configs/rover_configs.yaml
@@ -150,8 +150,10 @@ access_log:
   protocol_analyze:
     # The size of socket data buffer on each CPU
     per_cpu_buffer: ${ROVER_ACCESS_LOG_PROTOCOL_ANALYZE_PER_CPU_BUFFER:400KB}
+    # The count of parallel protocol event parse
+    parse_parallels: ${ROVER_ACCESS_LOG_PROTOCOL_ANALYZE_PARSE_PARALLELS:2}
     # The count of parallel protocol analyzer
-    parallels: ${ROVER_ACCESS_LOG_PROTOCOL_ANALYZE_PARALLELS:2}
+    analyze_parallels: ${ROVER_ACCESS_LOG_PROTOCOL_ANALYZE_PARALLELS:2}
     # The size of per paralleled analyzer queue
     queue_size: ${ROVER_ACCESS_LOG_PROTOCOL_ANALYZE_QUEUE_SIZE:5000}
 

--- a/pkg/accesslog/collector/connection.go
+++ b/pkg/accesslog/collector/connection.go
@@ -77,12 +77,12 @@ func (c *ConnectCollector) Start(_ *module.Manager, ctx *common.AccessLogContext
 	c.eventQueue = btf.NewEventQueue(ctx.Config.ConnectionAnalyze.Parallels, ctx.Config.ConnectionAnalyze.QueueSize, func(num int) btf.PartitionContext {
 		return newConnectionPartitionContext(ctx, track)
 	})
-	c.eventQueue.RegisterReceiver(ctx.BPF.SocketConnectionEventQueue, int(perCPUBufferSize), func() interface{} {
+	c.eventQueue.RegisterReceiver(ctx.BPF.SocketConnectionEventQueue, int(perCPUBufferSize), 1, func() interface{} {
 		return &events.SocketConnectEvent{}
 	}, func(data interface{}) string {
 		return fmt.Sprintf("%d", data.(*events.SocketConnectEvent).ConID)
 	})
-	c.eventQueue.RegisterReceiver(ctx.BPF.SocketCloseEventQueue, int(perCPUBufferSize), func() interface{} {
+	c.eventQueue.RegisterReceiver(ctx.BPF.SocketCloseEventQueue, int(perCPUBufferSize), 1, func() interface{} {
 		return &events.SocketCloseEvent{}
 	}, func(data interface{}) string {
 		return fmt.Sprintf("%d", data.(*events.SocketCloseEvent).ConnectionID)

--- a/pkg/accesslog/common/config.go
+++ b/pkg/accesslog/common/config.go
@@ -43,7 +43,8 @@ type ConnectionAnalyzeConfig struct {
 
 type ProtocolAnalyzeConfig struct {
 	PerCPUBufferSize string `mapstructure:"per_cpu_buffer"`
-	Parallels        int    `mapstructure:"parallels"`
+	ParseParallels   int    `mapstructure:"parse_parallels"`
+	AnalyzeParallels int    `mapstructure:"analyze_parallels"`
 	QueueSize        int    `mapstructure:"queue_size"`
 }
 

--- a/pkg/profiling/continuous/checker/bpf/network/network.go
+++ b/pkg/profiling/continuous/checker/bpf/network/network.go
@@ -147,7 +147,7 @@ func startBPFIfNeed() error {
 			n.ReceiveBufferEvent(event)
 		}
 	})
-	bpfLinker.ReadEventAsyncWithBufferSize(bpf.SocketBufferSendQueue, reader.Read, os.Getpagesize()*100, reader.BufferDataBPFSupplier)
+	bpfLinker.ReadEventAsyncWithBufferSize(bpf.SocketBufferSendQueue, reader.Read, os.Getpagesize()*100, 1, reader.BufferDataBPFSupplier)
 
 	if err := bpfLinker.HasError(); err != nil {
 		_ = bpfLinker.Close()

--- a/pkg/profiling/task/network/analyze/layer7/events.go
+++ b/pkg/profiling/task/network/analyze/layer7/events.go
@@ -36,14 +36,14 @@ func (l *Listener) initSocketDataQueue(parallels, queueSize int, config *profili
 
 func (l *Listener) startSocketData(ctx context.Context, bpfLoader *bpf.Loader) {
 	// socket buffer data
-	l.socketDataQueue.RegisterReceiver(bpfLoader.SocketDataUploadEventQueue, l.protocolPerCPUBuffer, func() interface{} {
+	l.socketDataQueue.RegisterReceiver(bpfLoader.SocketDataUploadEventQueue, l.protocolPerCPUBuffer, 1, func() interface{} {
 		return &analyzeBase.SocketDataUploadEvent{}
 	}, func(data interface{}) string {
 		return data.(*analyzeBase.SocketDataUploadEvent).GenerateConnectionID()
 	})
 
 	// socket detail
-	l.socketDataQueue.RegisterReceiver(bpfLoader.SocketDetailDataQueue, l.protocolPerCPUBuffer, func() interface{} {
+	l.socketDataQueue.RegisterReceiver(bpfLoader.SocketDetailDataQueue, l.protocolPerCPUBuffer, 1, func() interface{} {
 		return &analyzeBase.SocketDetailEvent{}
 	}, func(data interface{}) string {
 		return data.(*analyzeBase.SocketDetailEvent).GenerateConnectionID()

--- a/pkg/tools/btf/linker.go
+++ b/pkg/tools/btf/linker.go
@@ -159,7 +159,8 @@ func (m *Linker) ReadEventAsync(emap *ebpf.Map, bufReader RingBufferReader, data
 	m.ReadEventAsyncWithBufferSize(emap, bufReader, os.Getpagesize(), 1, dataSupplier)
 }
 
-func (m *Linker) ReadEventAsyncWithBufferSize(emap *ebpf.Map, bufReader RingBufferReader, perCPUBuffer, parallels int, dataSupplier func() interface{}) {
+func (m *Linker) ReadEventAsyncWithBufferSize(emap *ebpf.Map, bufReader RingBufferReader, perCPUBuffer,
+	parallels int, dataSupplier func() interface{}) {
 	rd, err := perf.NewReader(emap, perCPUBuffer)
 	if err != nil {
 		m.errors = multierror.Append(m.errors, fmt.Errorf("open ring buffer error: %v", err))

--- a/pkg/tools/btf/linker.go
+++ b/pkg/tools/btf/linker.go
@@ -156,17 +156,27 @@ func (m *Linker) AddTracePoint(sys, name string, p *ebpf.Program) {
 }
 
 func (m *Linker) ReadEventAsync(emap *ebpf.Map, bufReader RingBufferReader, dataSupplier func() interface{}) {
-	m.ReadEventAsyncWithBufferSize(emap, bufReader, os.Getpagesize(), dataSupplier)
+	m.ReadEventAsyncWithBufferSize(emap, bufReader, os.Getpagesize(), 1, dataSupplier)
 }
 
-func (m *Linker) ReadEventAsyncWithBufferSize(emap *ebpf.Map, bufReader RingBufferReader, perCPUBuffer int, dataSupplier func() interface{}) {
+func (m *Linker) ReadEventAsyncWithBufferSize(emap *ebpf.Map, bufReader RingBufferReader, perCPUBuffer, parallels int, dataSupplier func() interface{}) {
 	rd, err := perf.NewReader(emap, perCPUBuffer)
 	if err != nil {
 		m.errors = multierror.Append(m.errors, fmt.Errorf("open ring buffer error: %v", err))
 		return
 	}
+	if parallels < 1 {
+		m.errors = multierror.Append(m.errors, fmt.Errorf("parallels rading count must bigger than 1"))
+		return
+	}
 	m.closers = append(m.closers, rd)
 
+	for i := 0; i < parallels; i++ {
+		m.asyncReadEvent(rd, emap, dataSupplier, bufReader)
+	}
+}
+
+func (m *Linker) asyncReadEvent(rd *perf.Reader, emap *ebpf.Map, dataSupplier func() interface{}, bufReader RingBufferReader) {
 	go func() {
 		for {
 			record, err := rd.Read()


### PR DESCRIPTION
When the business system traffic is high, the Rover will convert its traffic between kernel mode and user mode through BPF Queue. Previously, there was only a single goroutine to receive, parse, and then send it to the routing analysis goroutine. This caused the parsing process to require waiting until the next receive. 
Therefore, it now supports multiple goroutines to receive and parse events in the queue from being discarded due to waiting for parsing during high traffic.

This is similar to the concept of boss and worker groups in Netty, where boss and worker groups are two separate thread pools. The boss is responsible for receiving connections, while the worker handles processing them. In Rover, the boss (parse) group receives events, and the worker (analyze) group processes events.