### PR TITLE
Introduce ringbuf queue in access log module

### DIFF
--- a/.github/workflows/rover.yaml
+++ b/.github/workflows/rover.yaml
@@ -342,7 +342,7 @@ jobs:
         if: ${{ failure() }}
         name: Upload Logs
         with:
-          name: logs
+          name: logs ${{ matrix.test.name }}
           path: "${{ env.SW_INFRA_E2E_LOG_DIR }}"
 
   required:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Release Notes.
 * Fix missing the first socket detail event in HTTPS protocol.
 * Support parallel parsing protocol data in the access log module.
 * Upgrade Go library to `1.22`, eBPF library to `0.16.0`.
+* Introduce ringbuf queue to improve performance in the access log module.
 
 #### Bug Fixes
 * Fix the base image cannot run in the arm64.

--- a/bpf/include/queue.h
+++ b/bpf/include/queue.h
@@ -1,0 +1,61 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "api.h"
+
+#define DATA_QUEUE(name, size)               \
+	struct {                                    \
+		__uint(type, BPF_MAP_TYPE_RINGBUF); \
+		__uint(max_entries, size);          \
+	} name SEC(".maps");                        \
+	const void *rover_data_queue_##name __attribute__((unused));
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, 10240); // all events are less than 10KB
+} rover_data_heap SEC(".maps");
+
+static __always_inline void *rover_reserve_buf(void *map, __u64 size) {
+	static const int zero = 0;
+
+	if (bpf_core_enum_value_exists(enum bpf_func_id,
+				       BPF_FUNC_ringbuf_reserve))
+		return bpf_ringbuf_reserve(map, size, 0);
+
+	return bpf_map_lookup_elem(&rover_data_heap, &zero);
+}
+
+static __always_inline void rover_discard_buf(void *buf)
+{
+	if (bpf_core_enum_value_exists(enum bpf_func_id,
+				       BPF_FUNC_ringbuf_discard))
+		bpf_ringbuf_discard(buf, 0);
+}
+
+static __always_inline long rover_submit_buf(void *ctx, void *map, void *buf, __u64 size) {
+	if (bpf_core_enum_value_exists(enum bpf_func_id,
+				       BPF_FUNC_ringbuf_submit)) {
+		bpf_ringbuf_submit(buf, 0);
+		return 0;
+	}
+
+	return bpf_perf_event_output(ctx, map, BPF_F_CURRENT_CPU, buf, size);
+}

--- a/pkg/accesslog/bpf/loader.go
+++ b/pkg/accesslog/bpf/loader.go
@@ -34,7 +34,7 @@ type Loader struct {
 
 func NewLoader() (*Loader, error) {
 	objs := bpfObjects{}
-	if err := loadBpfObjects(&objs, btf.GetEBPFCollectionOptionsIfNeed()); err != nil {
+	if err := btf.LoadBPFAndAssign(loadBpf, &objs); err != nil {
 		return nil, err
 	}
 

--- a/pkg/accesslog/collector/protocols/queue.go
+++ b/pkg/accesslog/collector/protocols/queue.go
@@ -92,13 +92,13 @@ func (q *AnalyzeQueue) Start(ctx context.Context) {
 		func(num int) btf.PartitionContext {
 			return NewPartitionContext(q.context, num, q.supportAnalyzers(q.context))
 		})
-	q.eventQueue.RegisterReceiver(q.context.BPF.SocketDetailDataQueue, int(q.perCPUBuffer),
+	q.eventQueue.RegisterReceiver(q.context.BPF.SocketDetailQueue, int(q.perCPUBuffer),
 		q.context.Config.ProtocolAnalyze.ParseParallels, func() interface{} {
 			return q.detailSupplier()
 		}, func(data interface{}) string {
 			return fmt.Sprintf("%d", data.(events.SocketDetail).GetConnectionID())
 		})
-	q.eventQueue.RegisterReceiver(q.context.BPF.SocketDataUploadEventQueue, int(q.perCPUBuffer),
+	q.eventQueue.RegisterReceiver(q.context.BPF.SocketDataUploadQueue, int(q.perCPUBuffer),
 		q.context.Config.ProtocolAnalyze.ParseParallels, func() interface{} {
 			return &events.SocketDataUploadEvent{}
 		}, func(data interface{}) string {

--- a/pkg/profiling/continuous/checker/bpf/network/network.go
+++ b/pkg/profiling/continuous/checker/bpf/network/network.go
@@ -134,7 +134,7 @@ func startBPFIfNeed() error {
 	}
 
 	bpf = &bpfObjects{}
-	if err := btf.LoadBPFAndAssign(loadBpf, &bpf); err != nil {
+	if err := btf.LoadBPFAndAssign(loadBpf, bpf); err != nil {
 		return err
 	}
 

--- a/pkg/profiling/continuous/checker/bpf/network/network.go
+++ b/pkg/profiling/continuous/checker/bpf/network/network.go
@@ -134,9 +134,10 @@ func startBPFIfNeed() error {
 	}
 
 	bpf = &bpfObjects{}
-	if err := loadBpfObjects(bpf, btf.GetEBPFCollectionOptionsIfNeed()); err != nil {
+	if err := btf.LoadBPFAndAssign(loadBpf, &bpf); err != nil {
 		return err
 	}
+
 	bpfLinker = btf.NewLinker()
 	bpfLinker.AddLink(link.Kprobe, map[string]*ebpf.Program{"tcp_sendmsg": bpf.TcpSendmsg})
 	bpfLinker.AddLink(link.Kprobe, map[string]*ebpf.Program{"tcp_recvmsg": bpf.TcpRecvmsg})

--- a/pkg/profiling/task/network/analyze/layer7/events.go
+++ b/pkg/profiling/task/network/analyze/layer7/events.go
@@ -36,7 +36,7 @@ func (l *Listener) initSocketDataQueue(parallels, queueSize int, config *profili
 
 func (l *Listener) startSocketData(ctx context.Context, bpfLoader *bpf.Loader) {
 	// socket buffer data
-	l.socketDataQueue.RegisterReceiver(bpfLoader.SocketDataUploadEventQueue, l.protocolPerCPUBuffer, 1, func() interface{} {
+	l.socketDataQueue.RegisterReceiver(bpfLoader.SocketDataUploadQueue, l.protocolPerCPUBuffer, 1, func() interface{} {
 		return &analyzeBase.SocketDataUploadEvent{}
 	}, func(data interface{}) string {
 		return data.(*analyzeBase.SocketDataUploadEvent).GenerateConnectionID()

--- a/pkg/profiling/task/network/analyze/layer7/protocols/http1/reader/reader.go
+++ b/pkg/profiling/task/network/analyze/layer7/protocols/http1/reader/reader.go
@@ -104,11 +104,19 @@ func (m *MessageOpt) ContentTotalSize() int {
 }
 
 func (m *MessageOpt) StartTime() uint64 {
-	return m.HeaderBuffer().FirstSocketBuffer().StartTime()
+	socketBuffer := m.HeaderBuffer().FirstSocketBuffer()
+	if socketBuffer == nil {
+		return 0
+	}
+	return socketBuffer.StartTime()
 }
 
 func (m *MessageOpt) EndTime() uint64 {
-	return m.BodyBuffer().LastSocketBuffer().EndTime()
+	socketBuffer := m.BodyBuffer().LastSocketBuffer()
+	if socketBuffer == nil {
+		return m.StartTime()
+	}
+	return socketBuffer.EndTime()
 }
 
 func (m *MessageOpt) Direction() enums.SocketDataDirection {

--- a/pkg/profiling/task/network/bpf/bpf.go
+++ b/pkg/profiling/task/network/bpf/bpf.go
@@ -34,7 +34,7 @@ type Loader struct {
 
 func NewLoader() (*Loader, error) {
 	objs := bpfObjects{}
-	if err := loadBpfObjects(&objs, btf.GetEBPFCollectionOptionsIfNeed()); err != nil {
+	if err := btf.LoadBPFAndAssign(loadBpf, &objs); err != nil {
 		return nil, err
 	}
 

--- a/pkg/profiling/task/offcpu/runner.go
+++ b/pkg/profiling/task/offcpu/runner.go
@@ -113,7 +113,7 @@ func (r *Runner) Run(ctx context.Context, notify base.ProfilingRunningSuccessNot
 	if !replacedPid {
 		return fmt.Errorf("replace the monitor pid failure")
 	}
-	if err1 := spec.LoadAndAssign(&objs, btf.GetEBPFCollectionOptionsIfNeed()); err1 != nil {
+	if err1 := spec.LoadAndAssign(&objs, btf.GetEBPFCollectionOptionsIfNeed(spec)); err1 != nil {
 		return err1
 	}
 	r.bpf = &objs

--- a/pkg/tools/btf/ebpf.go
+++ b/pkg/tools/btf/ebpf.go
@@ -20,6 +20,7 @@ package btf
 import (
 	"bytes"
 	"embed"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -41,7 +42,16 @@ var (
 	log = logger.GetLogger("tools", "btf")
 )
 
-func GetEBPFCollectionOptionsIfNeed() *ebpf.CollectionOptions {
+func LoadBPFAndAssign(loadBPF func() (*ebpf.CollectionSpec, error), objs interface{}) error {
+	bpf, err := loadBPF()
+	if err != nil {
+		return err
+	}
+
+	return bpf.LoadAndAssign(objs, GetEBPFCollectionOptionsIfNeed(bpf))
+}
+
+func GetEBPFCollectionOptionsIfNeed(bpfSpec *ebpf.CollectionSpec) *ebpf.CollectionOptions {
 	findBTFOnce.Do(func() {
 		readSpec, err := getKernelBTFAddress()
 		if err != nil {
@@ -52,6 +62,7 @@ func GetEBPFCollectionOptionsIfNeed() *ebpf.CollectionOptions {
 		spec = readSpec
 	})
 
+	enhanceDataQueueOpts(bpfSpec)
 	return &ebpf.CollectionOptions{Programs: ebpf.ProgramOptions{KernelTypes: spec}}
 }
 
@@ -86,4 +97,32 @@ func getKernelBTFAddress() (spec *btf.Spec, err error) {
 
 func asset(file string) ([]byte, error) {
 	return assets.ReadFile(filepath.ToSlash(file))
+}
+
+func validateGlobalConstVoidPtrVar(t btf.Type) error {
+	btfVar, ok := t.(*btf.Var)
+	if !ok {
+		return errors.New("not of type btf.Var")
+	}
+
+	if btfVar.Linkage != btf.GlobalVar {
+		return fmt.Errorf("%q is not a global variable", btfVar.Name)
+	}
+
+	btfPtr, ok := btfVar.Type.(*btf.Pointer)
+	if !ok {
+		return fmt.Errorf("%q is not a pointer", btfVar.Name)
+	}
+
+	btfConst, ok := btfPtr.Target.(*btf.Const)
+	if !ok {
+		return fmt.Errorf("%q is not const", btfVar.Name)
+	}
+
+	_, ok = btfConst.Type.(*btf.Void)
+	if !ok {
+		return fmt.Errorf("%q is not a const void pointer", btfVar.Name)
+	}
+
+	return nil
 }

--- a/pkg/tools/btf/linker.go
+++ b/pkg/tools/btf/linker.go
@@ -188,6 +188,9 @@ func (m *Linker) asyncReadEvent(rd queueReader, emap *ebpf.Map, dataSupplier fun
 				log.Warnf("read from %s ringbuffer error: %v", emap.String(), err)
 				continue
 			}
+			if len(sample) == 0 {
+				continue
+			}
 
 			data := dataSupplier()
 			if r, ok := data.(reader.EventReader); ok {

--- a/pkg/tools/btf/queue.go
+++ b/pkg/tools/btf/queue.go
@@ -39,12 +39,12 @@ var (
 
 func isRingbufAvailable() bool {
 	ringbufChecker.Do(func() {
-		ringbuf, err := ebpf.NewMap(&ebpf.MapSpec{
+		buf, err := ebpf.NewMap(&ebpf.MapSpec{
 			Type:       ebpf.RingBuf,
 			MaxEntries: uint32(os.Getpagesize()),
 		})
 
-		ringbuf.Close()
+		buf.Close()
 
 		ringbufAvailable = err == nil
 

--- a/pkg/tools/btf/queue.go
+++ b/pkg/tools/btf/queue.go
@@ -19,11 +19,133 @@ package btf
 
 import (
 	"context"
+	"fmt"
 	"hash/fnv"
+	"os"
+	"strings"
 	"sync"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/perf"
+	"github.com/cilium/ebpf/ringbuf"
 )
+
+const dataQueuePrefix = "rover_data_queue_"
+
+var (
+	ringbufChecker   sync.Once
+	ringbufAvailable bool
+)
+
+func isRingbufAvailable() bool {
+	ringbufChecker.Do(func() {
+		ringbuf, err := ebpf.NewMap(&ebpf.MapSpec{
+			Type:       ebpf.RingBuf,
+			MaxEntries: uint32(os.Getpagesize()),
+		})
+
+		ringbuf.Close()
+
+		ringbufAvailable = err == nil
+
+		if ringbufAvailable {
+			log.Infof("detect the ring buffer is available in current system for enhancement of data queue")
+		}
+	})
+
+	return ringbufAvailable
+}
+
+func enhanceDataQueueOpts(bpfSpec *ebpf.CollectionSpec) {
+	it := bpfSpec.Types.Iterate()
+	for it.Next() {
+		if !strings.HasPrefix(it.Type.TypeName(), dataQueuePrefix) {
+			continue
+		}
+		if err := validateGlobalConstVoidPtrVar(it.Type); err != nil {
+			panic(fmt.Errorf("invalid global const void ptr var %s: %v", it.Type.TypeName(), err))
+		}
+
+		// if the ringbuf not available, use perf event array
+		if !isRingbufAvailable() {
+			mapName := strings.TrimPrefix(it.Type.TypeName(), dataQueuePrefix)
+			mapSpec := bpfSpec.Maps[mapName]
+			mapSpec.Type = ebpf.PerfEventArray
+			mapSpec.KeySize = 4
+			mapSpec.ValueSize = 4
+		}
+	}
+}
+
+type queueReader interface {
+	Read() ([]byte, error)
+	Close() error
+}
+
+func newQueueReader(emap *ebpf.Map, perCPUBuffer int) (queueReader, error) {
+	switch emap.Type() {
+	case ebpf.RingBuf:
+		return newRingBufReader(emap)
+	case ebpf.PerfEventArray:
+		return newPerfQueueReader(emap, perCPUBuffer)
+	}
+	return nil, fmt.Errorf("unsupported map type: %s", emap.Type().String())
+}
+
+type perfQueueReader struct {
+	name   string
+	reader *perf.Reader
+}
+
+func newPerfQueueReader(emap *ebpf.Map, perCPUBuffer int) (*perfQueueReader, error) {
+	reader, err := perf.NewReader(emap, perCPUBuffer)
+	if err != nil {
+		return nil, err
+	}
+	return &perfQueueReader{reader: reader, name: emap.String()}, nil
+}
+
+func (p *perfQueueReader) Read() ([]byte, error) {
+	read, err := p.reader.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	if read.LostSamples != 0 {
+		log.Warnf("perf event queue(%s) full, dropped %d samples", p.name, read.LostSamples)
+		return nil, nil
+	}
+
+	return read.RawSample, nil
+}
+
+func (p *perfQueueReader) Close() error {
+	return p.reader.Close()
+}
+
+type ringBufReader struct {
+	reader *ringbuf.Reader
+}
+
+func newRingBufReader(emap *ebpf.Map) (*ringBufReader, error) {
+	reader, err := ringbuf.NewReader(emap)
+	if err != nil {
+		return nil, err
+	}
+	return &ringBufReader{reader: reader}, nil
+}
+
+func (r *ringBufReader) Read() ([]byte, error) {
+	read, err := r.reader.Read()
+	if err != nil {
+		return nil, err
+	}
+	return read.RawSample, nil
+}
+
+func (r *ringBufReader) Close() error {
+	return r.reader.Close()
+}
 
 type PartitionContext interface {
 	Start(ctx context.Context)

--- a/pkg/tools/buffer/buffer.go
+++ b/pkg/tools/buffer/buffer.go
@@ -367,14 +367,14 @@ func (r *Buffer) DataSize() int64 {
 }
 
 func (r *Buffer) FirstSocketBuffer() SocketDataBuffer {
-	if r.dataEvents == nil || r.dataEvents.Len() == 0 {
+	if r == nil || r.dataEvents == nil || r.dataEvents.Len() == 0 {
 		return nil
 	}
 	return r.dataEvents.Front().Value.(SocketDataBuffer)
 }
 
 func (r *Buffer) LastSocketBuffer() SocketDataBuffer {
-	if r.dataEvents == nil || r.dataEvents.Len() == 0 {
+	if r == nil || r.dataEvents == nil || r.dataEvents.Len() == 0 {
 		return nil
 	}
 	return r.dataEvents.Back().Value.(SocketDataBuffer)
@@ -382,7 +382,7 @@ func (r *Buffer) LastSocketBuffer() SocketDataBuffer {
 
 // DetectNotSendingLastPosition detect the buffer contains not sending data: the BPF limited socket data count
 func (r *Buffer) DetectNotSendingLastPosition() *Position {
-	if r.dataEvents.Len() == 0 {
+	if r == nil || r.dataEvents.Len() == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
In Linux version 5.8, a ring buffer was introduced to replace the original perf buffer array to enhance transmission performance between kernel space and user space. 
Therefore, the access log module can optimize execution efficiency based on whether the system provides a ring buffer data structure.