### PR TITLE
Fully reading buffer and downgrade log level

### DIFF
--- a/pkg/accesslog/collector/protocols/http1.go
+++ b/pkg/accesslog/collector/protocols/http1.go
@@ -112,7 +112,7 @@ func (p *HTTP1Protocol) Analyze(connection *PartitionConnection, _ *AnalyzeHelpe
 			result = enums.ParseResultSkipPackage
 		}
 		if err != nil {
-			http1Log.Warnf("failed to handle HTTP/1.x protocol, connection ID: %d, random ID: %d, data id: %d, type: %d, error: %v",
+			http1Log.Debugf("failed to handle HTTP/1.x protocol, connection ID: %d, random ID: %d, data id: %d, type: %d, error: %v",
 				metrics.ConnectionID, metrics.RandomID, buf.Position().DataID(), messageType, err)
 		}
 


### PR DESCRIPTION
Fully read the buffer data when decoding HTTP data, and downgrade the warning log for the useless log. 