### PR TITLE
chore(deps): bump up go to 1.26

### DIFF
--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - id: auth
         uses: google-github-actions/auth@v1
         with:

--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -43,9 +43,9 @@ jobs:
         with:
           submodules: true
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.x"
       - id: auth
         uses: google-github-actions/auth@v1
         with:

--- a/.github/workflows/rover.yaml
+++ b/.github/workflows/rover.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/rover.yaml
+++ b/.github/workflows/rover.yaml
@@ -24,9 +24,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.x"
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25
+FROM golang:1.26
 
 RUN apt update -y && apt upgrade -y && \
     git clone --depth 1 --branch v1.1.0 https://github.com/libbpf/libbpf.git && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/skywalking-rover
 
-go 1.25
+go 1.26
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.9.0

--- a/pkg/accesslog/collector/l24.go
+++ b/pkg/accesslog/collector/l24.go
@@ -25,6 +25,18 @@ import (
 	"github.com/cilium/ebpf/link"
 )
 
+const (
+	kprobeIPRcv              = "ip_rcv"
+	kprobeIPListRcv          = "ip_list_rcv"
+	kprobeTCPV4Rcv           = "tcp_v4_rcv"
+	kprobeTCPV6Rcv           = "tcp_v6_rcv"
+	kprobeTCPSendmsg         = "tcp_sendmsg"
+	kprobeIPQueueXmit        = "__ip_queue_xmit"
+	kprobeNeighResolveOutput = "neigh_resolve_output"
+	kprobeNfHookSlow         = "nf_hook_slow"
+	kprobeDevQueueXmit       = "__dev_queue_xmit"
+)
+
 var l24CollectorsInstance = NewL24Collector()
 
 type L24Collector struct {
@@ -45,47 +57,47 @@ func (c *L24Collector) startRead(_ *module.Manager, context *common.AccessLogCon
 	context.BPF.AddTracePoint("net", "netif_receive_skb", context.BPF.TracepointNetifReceiveSkb)
 
 	// l3
-	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"ip_rcv": context.BPF.IpRcv})
-	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{"ip_rcv": context.BPF.IpRcvRet})
+	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{kprobeIPRcv: context.BPF.IpRcv})
+	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{kprobeIPRcv: context.BPF.IpRcvRet})
 	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"ip_rcv_finish": context.BPF.IpRcvFinish})
 	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"ip_local_deliver": context.BPF.IpLocalDeliver})
 	// it's not exist in old kernel versions
-	_ = context.BPF.AddLinkOrError(link.Kprobe, map[string]*ebpf.Program{"ip_list_rcv": context.BPF.IpListRcv})
-	_ = context.BPF.AddLinkOrError(link.Kretprobe, map[string]*ebpf.Program{"ip_list_rcv": context.BPF.IpListRcvRet})
+	_ = context.BPF.AddLinkOrError(link.Kprobe, map[string]*ebpf.Program{kprobeIPListRcv: context.BPF.IpListRcv})
+	_ = context.BPF.AddLinkOrError(link.Kretprobe, map[string]*ebpf.Program{kprobeIPListRcv: context.BPF.IpListRcvRet})
 	_ = context.BPF.AddLinkOrError(link.Kprobe, map[string]*ebpf.Program{"ip_sublist_rcv_finish": context.BPF.IpSublistRcvFinish})
 	_ = context.BPF.AddLinkOrError(link.Kprobe, map[string]*ebpf.Program{"ip_local_deliver_finish": context.BPF.IpLocalDeliverFinish})
 
 	// l4
-	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"tcp_v4_rcv": context.BPF.TcpV4Rcv})
-	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{"tcp_v4_rcv": context.BPF.TcpV4RcvRet})
-	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"tcp_v6_rcv": context.BPF.TcpV6Rcv})
-	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{"tcp_v6_rcv": context.BPF.TcpV6RcvRet})
+	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{kprobeTCPV4Rcv: context.BPF.TcpV4Rcv})
+	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{kprobeTCPV4Rcv: context.BPF.TcpV4RcvRet})
+	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{kprobeTCPV6Rcv: context.BPF.TcpV6Rcv})
+	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{kprobeTCPV6Rcv: context.BPF.TcpV6RcvRet})
 }
 
 func (c *L24Collector) startWrite(_ *module.Manager, context *common.AccessLogContext) {
 	// l4
-	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"tcp_sendmsg": context.BPF.TcpSendmsg})
-	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{"tcp_sendmsg": context.BPF.TcpSendmsgRet})
+	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{kprobeTCPSendmsg: context.BPF.TcpSendmsg})
+	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{kprobeTCPSendmsg: context.BPF.TcpSendmsgRet})
 	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"__tcp_transmit_skb": context.BPF.TcpTransmitSkb})
 	context.BPF.AddTracePoint("tcp", "tcp_retransmit_skb", context.BPF.TracepointTcpRetransmitSkb)
 	context.BPF.AddTracePoint("skb", "kfree_skb", context.BPF.KfreeSkb)
 
 	// l3
-	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"__ip_queue_xmit": context.BPF.IpQueueXmit})
-	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{"__ip_queue_xmit": context.BPF.IpQueueXmitRet})
+	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{kprobeIPQueueXmit: context.BPF.IpQueueXmit})
+	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{kprobeIPQueueXmit: context.BPF.IpQueueXmitRet})
 	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"__ip_local_out": context.BPF.IpLocal})
 	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"ip_output": context.BPF.IpOutput})
 	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"ip_finish_output2": context.BPF.IpFinishOutput2})
-	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"neigh_resolve_output": context.BPF.NeighResolveOutput})
-	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{"neigh_resolve_output": context.BPF.NeighResolveOutputRet})
+	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{kprobeNeighResolveOutput: context.BPF.NeighResolveOutput})
+	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{kprobeNeighResolveOutput: context.BPF.NeighResolveOutputRet})
 
 	// netlink
-	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"nf_hook_slow": context.BPF.NfHookSlow})
-	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{"nf_hook_slow": context.BPF.NfHookSlowRet})
+	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{kprobeNfHookSlow: context.BPF.NfHookSlow})
+	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{kprobeNfHookSlow: context.BPF.NfHookSlowRet})
 
 	// l2
-	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{"__dev_queue_xmit": context.BPF.DevQueueEmit})
-	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{"__dev_queue_xmit": context.BPF.DevQueueEmitRet})
+	context.BPF.AddLink(link.Kprobe, map[string]*ebpf.Program{kprobeDevQueueXmit: context.BPF.DevQueueEmit})
+	context.BPF.AddLink(link.Kretprobe, map[string]*ebpf.Program{kprobeDevQueueXmit: context.BPF.DevQueueEmitRet})
 	context.BPF.AddTracePoint("net", "net_dev_start_xmit", context.BPF.TracepointNetDevStartXmit)
 	context.BPF.AddTracePoint("net", "net_dev_xmit", context.BPF.TracepointNetDevXmit)
 }

--- a/pkg/boot/module_test.go
+++ b/pkg/boot/module_test.go
@@ -26,74 +26,80 @@ import (
 	"github.com/apache/skywalking-rover/pkg/module"
 )
 
+const (
+	moduleTest1 = "test1"
+	moduleTest2 = "test2"
+	moduleTest3 = "test3"
+)
+
 func TestResolveDependency(t *testing.T) {
 	tests := []testDependencyStruct{
 		{
 			name: "no dependency",
 			moduleWithDependencies: map[string][]string{
-				"test1": nil,
-				"test2": nil,
+				moduleTest1: nil,
+				moduleTest2: nil,
 			},
 			setupModules: []string{
-				"test1", "test2",
+				moduleTest1, moduleTest2,
 			},
 			expectSequence: []string{
-				"test1", "test2",
+				moduleTest1, moduleTest2,
 			},
 		},
 		{
 			name: "test1 on test2",
 			moduleWithDependencies: map[string][]string{
-				"test1": {"test2"},
-				"test2": nil,
+				moduleTest1: {moduleTest2},
+				moduleTest2: nil,
 			},
 			setupModules: []string{
-				"test1", "test2",
+				moduleTest1, moduleTest2,
 			},
 			expectSequence: []string{
-				"test2", "test1",
+				moduleTest2, moduleTest1,
 			},
 		},
 		{
 			name: "test1 depend on test2, and other no depend test3",
 			moduleWithDependencies: map[string][]string{
-				"test1": {"test2"},
-				"test2": nil,
-				"test3": nil,
+				moduleTest1: {moduleTest2},
+				moduleTest2: nil,
+				moduleTest3: nil,
 			},
 			setupModules: []string{
-				"test1", "test2", "test3",
+				moduleTest1, moduleTest2, moduleTest3,
 			},
 			expectSequence: []string{
-				"test2", "test1", "test3",
+				moduleTest2, moduleTest1, moduleTest3,
 			},
 		},
 		{
 			name: "test1 depend on test2 and test2 depend on test3",
 			moduleWithDependencies: map[string][]string{
-				"test1": {"test2"},
-				"test2": {"test3"},
-				"test3": nil,
+				moduleTest1: {moduleTest2},
+				moduleTest2: {moduleTest3},
+				moduleTest3: nil,
 			},
 			setupModules: []string{
-				"test1", "test2", "test3",
+				moduleTest1, moduleTest2, moduleTest3,
 			},
 			expectSequence: []string{
-				"test3", "test2", "test1",
+				moduleTest3, moduleTest2, moduleTest1,
 			},
 		},
 		{
 			name: "test1 depend on test2 and test3, and test2 depend on test3",
 			moduleWithDependencies: map[string][]string{
-				"test1": {"test2", "test3"},
-				"test2": {"test3"},
-				"test3": nil,
+				moduleTest1: {moduleTest2, moduleTest3},
+				moduleTest2: {moduleTest3},
+				moduleTest3: nil,
 			},
 			setupModules: []string{
-				"test1", "test2", "test3",
+				moduleTest1, moduleTest2, moduleTest3,
 			},
 			expectSequence: []string{
-				"test3", "test2", "test1",
+				moduleTest3, moduleTest2, moduleTest1,
 			},
 		},
 	}
@@ -147,20 +153,20 @@ func TestRun(t *testing.T) {
 		{
 			name: "simple and shutdown by module",
 			dependencies: map[string][]string{
-				"test1": nil,
-				"test2": nil,
+				moduleTest1: nil,
+				moduleTest2: nil,
 			},
 			modules: []string{
-				"test1", "test2",
+				moduleTest1, moduleTest2,
 			},
 			startSequence: []string{
-				"test1", "test2",
+				moduleTest1, moduleTest2,
 			},
 			startNotifySequence: []string{
-				"test1", "test2",
+				moduleTest1, moduleTest2,
 			},
 			shutdownSequence: []string{
-				"test2", "test1",
+				moduleTest2, moduleTest1,
 			},
 			triggerShutdown: func(_ context.Context, _ context.CancelFunc, starter *ModuleStarter) {
 				starter.moduleManager.ShutdownModules(nil)
@@ -169,20 +175,20 @@ func TestRun(t *testing.T) {
 		{
 			name: "simple and shutdown by context.down",
 			dependencies: map[string][]string{
-				"test1": nil,
-				"test2": nil,
+				moduleTest1: nil,
+				moduleTest2: nil,
 			},
 			modules: []string{
-				"test1", "test2",
+				moduleTest1, moduleTest2,
 			},
 			startSequence: []string{
-				"test1", "test2",
+				moduleTest1, moduleTest2,
 			},
 			startNotifySequence: []string{
-				"test1", "test2",
+				moduleTest1, moduleTest2,
 			},
 			shutdownSequence: []string{
-				"test2", "test1",
+				moduleTest2, moduleTest1,
 			},
 			triggerShutdown: func(_ context.Context, cancel context.CancelFunc, _ *ModuleStarter) {
 				cancel()
@@ -191,20 +197,20 @@ func TestRun(t *testing.T) {
 		{
 			name: "dependency with module shutdown",
 			dependencies: map[string][]string{
-				"test1": {"test2"},
-				"test2": nil,
+				moduleTest1: {moduleTest2},
+				moduleTest2: nil,
 			},
 			modules: []string{
-				"test1", "test2",
+				moduleTest1, moduleTest2,
 			},
 			startSequence: []string{
-				"test2", "test1",
+				moduleTest2, moduleTest1,
 			},
 			startNotifySequence: []string{
-				"test2", "test1",
+				moduleTest2, moduleTest1,
 			},
 			shutdownSequence: []string{
-				"test1", "test2",
+				moduleTest1, moduleTest2,
 			},
 			triggerShutdown: func(_ context.Context, _ context.CancelFunc, starter *ModuleStarter) {
 				starter.moduleManager.ShutdownModules(nil)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,24 +24,33 @@ import (
 	"testing"
 )
 
+const (
+	caseNoEnv     = "no-env"
+	keyTestA      = "testa"
+	keyTestB      = "testb"
+	valueABC      = "abc"
+	valueZZZ      = "zzz"
+	fileConfigEnv = "testdata/config-env.yaml"
+)
+
 func TestLoad(t *testing.T) {
 	tests := []testLoadConfig{
 		{
-			name: "no-env",
+			name: caseNoEnv,
 			env:  nil,
 			file: "testdata/config-no-env.yaml",
 			topKeys: []string{
-				"testa", "testb",
+				keyTestA, keyTestB,
 			},
 			unmarshalls: map[string]struct {
 				newData  interface{}
 				validate interface{}
 			}{
-				"testa": {
+				keyTestA: {
 					newData:  &configWithString{},
-					validate: &configWithString{"abc"},
+					validate: &configWithString{valueABC},
 				},
-				"testb": {
+				keyTestB: {
 					newData:  &configWithInteger{},
 					validate: &configWithInteger{2},
 				},
@@ -50,19 +59,19 @@ func TestLoad(t *testing.T) {
 		{
 			name: "env-not-set",
 			env:  nil,
-			file: "testdata/config-env.yaml",
+			file: fileConfigEnv,
 			topKeys: []string{
-				"testa", "testb",
+				keyTestA, keyTestB,
 			},
 			unmarshalls: map[string]struct {
 				newData  interface{}
 				validate interface{}
 			}{
-				"testa": {
+				keyTestA: {
 					newData:  &configWithString{},
 					validate: &configWithString{"def"},
 				},
-				"testb": {
+				keyTestB: {
 					newData:  &configWithInteger{},
 					validate: &configWithInteger{456},
 				},
@@ -71,22 +80,22 @@ func TestLoad(t *testing.T) {
 		{
 			name: "env-set",
 			env: map[string]string{
-				"TEST_A_DATA": "zzz",
+				"TEST_A_DATA": valueZZZ,
 				"TEST_B_DATA": "999",
 			},
-			file: "testdata/config-env.yaml",
+			file: fileConfigEnv,
 			topKeys: []string{
-				"testa", "testb",
+				keyTestA, keyTestB,
 			},
 			unmarshalls: map[string]struct {
 				newData  interface{}
 				validate interface{}
 			}{
-				"testa": {
+				keyTestA: {
 					newData:  &configWithString{},
-					validate: &configWithString{"zzz"},
+					validate: &configWithString{valueZZZ},
 				},
-				"testb": {
+				keyTestB: {
 					newData:  &configWithInteger{},
 					validate: &configWithInteger{999},
 				},

--- a/pkg/config/env_override_test.go
+++ b/pkg/config/env_override_test.go
@@ -26,6 +26,16 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	keyData1 = "data1"
+	keyData2 = "data2"
+	keyData3 = "data3"
+	keyData4 = "data4"
+	keyData5 = "data5"
+	valueDEF = "DEF"
+	value456 = "456"
+)
+
 func TestOverrideEnv(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -34,18 +44,18 @@ func TestOverrideEnv(t *testing.T) {
 		result map[string]interface{}
 	}{
 		{
-			name: "no-env",
+			name: caseNoEnv,
 			env:  nil,
 			file: "testdata/override-no-env.yaml",
 			result: map[string]interface{}{
-				"data1": "abc",
-				"data2": 123,
-				"data3": []interface{}{1, 2},
-				"data4": map[string]interface{}{
+				keyData1: valueABC,
+				keyData2: 123,
+				keyData3: []interface{}{1, 2},
+				keyData4: map[string]interface{}{
 					"a": 1,
 					"b": 2,
 				},
-				"data5": []interface{}{
+				keyData5: []interface{}{
 					map[string]interface{}{
 						"a": 1,
 					},
@@ -55,8 +65,8 @@ func TestOverrideEnv(t *testing.T) {
 		{
 			name: "full-env",
 			env: map[string]string{
-				"TEST_1":           "DEF",
-				"TEST_2":           "456",
+				"TEST_1":           valueDEF,
+				"TEST_2":           value456,
 				"TEST_3_1":         "2",
 				"TEST_3_2_NOT_SET": "",
 				"TEST_4_A":         "3",
@@ -64,16 +74,16 @@ func TestOverrideEnv(t *testing.T) {
 			},
 			file: "testdata/override-env.yaml",
 			result: map[string]interface{}{
-				"data1": "DEF",
-				"data2": "456",
-				"data3": []interface{}{
+				keyData1: valueDEF,
+				keyData2: value456,
+				keyData3: []interface{}{
 					"2", "2",
 				},
-				"data4": map[string]interface{}{
+				keyData4: map[string]interface{}{
 					"a": "3",
 					"b": "1",
 				},
-				"data5": []interface{}{
+				keyData5: []interface{}{
 					map[string]interface{}{
 						"a": "3",
 					},

--- a/pkg/profiling/continuous/checker/bpf/network/network.go
+++ b/pkg/profiling/continuous/checker/bpf/network/network.go
@@ -35,6 +35,8 @@ import (
 // nolint
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -no-global-types -target $TARGET -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf $REPO_ROOT/bpf/profiling/continuous/network.c -- -I$REPO_ROOT/bpf/include
 
+const kprobeTCPRecvmsg = "tcp_recvmsg"
+
 var log = logger.GetLogger("profiling", "continuous", "checker", "network", "bpf")
 
 var locker sync.Mutex
@@ -140,8 +142,8 @@ func startBPFIfNeed() error {
 
 	bpfLinker = btf.NewLinker()
 	bpfLinker.AddLink(link.Kprobe, map[string]*ebpf.Program{"tcp_sendmsg": bpf.TcpSendmsg})
-	bpfLinker.AddLink(link.Kprobe, map[string]*ebpf.Program{"tcp_recvmsg": bpf.TcpRecvmsg})
-	bpfLinker.AddLink(link.Kretprobe, map[string]*ebpf.Program{"tcp_recvmsg": bpf.RetTcpRecvmsg})
+	bpfLinker.AddLink(link.Kprobe, map[string]*ebpf.Program{kprobeTCPRecvmsg: bpf.TcpRecvmsg})
+	bpfLinker.AddLink(link.Kretprobe, map[string]*ebpf.Program{kprobeTCPRecvmsg: bpf.RetTcpRecvmsg})
 
 	reader := newNetworkBufferReader(func(event BufferEvent) {
 		for _, n := range notifiers {

--- a/pkg/profiling/task/network/analyze/layer7/protocols/http1/metrics.go
+++ b/pkg/profiling/task/network/analyze/layer7/protocols/http1/metrics.go
@@ -47,6 +47,12 @@ var (
 	transportResponse = "Response"
 )
 
+const (
+	entityTagServiceName         = "service_name"
+	entityTagServiceInstanceName = "service_instance_name"
+	entityTagProcessName         = "process_name"
+)
+
 type URIMetrics struct {
 	RequestCounter *metrics.Counter
 	StatusCounter  map[int]*metrics.Counter
@@ -269,9 +275,9 @@ func (h *Trace) appendHTTPEvent(attaches []*v3.SpanAttachedEvent, process api.Pr
 		// connection
 		&commonv3.KeyStringValuePair{Key: "connection_role", Value: traffic.Role.String()},
 		// entity
-		&commonv3.KeyStringValuePair{Key: "service_name", Value: process.Entity().ServiceName},
-		&commonv3.KeyStringValuePair{Key: "service_instance_name", Value: process.Entity().InstanceName},
-		&commonv3.KeyStringValuePair{Key: "process_name", Value: process.Entity().ProcessName},
+		&commonv3.KeyStringValuePair{Key: entityTagServiceName, Value: process.Entity().ServiceName},
+		&commonv3.KeyStringValuePair{Key: entityTagServiceInstanceName, Value: process.Entity().InstanceName},
+		&commonv3.KeyStringValuePair{Key: entityTagProcessName, Value: process.Entity().ProcessName},
 	)
 
 	event.Summary = make([]*commonv3.KeyIntValuePair, 0)
@@ -322,9 +328,9 @@ func (h *Trace) appendPerDetailEvent(attaches []*v3.SpanAttachedEvent, process a
 		&commonv3.KeyStringValuePair{Key: "network_name", Value: host.NetworkName(int(detail.IfIndex))},
 		&commonv3.KeyStringValuePair{Key: "network_index", Value: fmt.Sprintf("%d", detail.IfIndex)},
 		// entity
-		&commonv3.KeyStringValuePair{Key: "service_name", Value: process.Entity().ServiceName},
-		&commonv3.KeyStringValuePair{Key: "service_instance_name", Value: process.Entity().InstanceName},
-		&commonv3.KeyStringValuePair{Key: "process_name", Value: process.Entity().ProcessName},
+		&commonv3.KeyStringValuePair{Key: entityTagServiceName, Value: process.Entity().ServiceName},
+		&commonv3.KeyStringValuePair{Key: entityTagServiceInstanceName, Value: process.Entity().InstanceName},
+		&commonv3.KeyStringValuePair{Key: entityTagProcessName, Value: process.Entity().ProcessName},
 	)
 
 	if detail.RTTTime > 0 {

--- a/pkg/profiling/task/network/analyze/layer7/protocols/http1/reader/reader.go
+++ b/pkg/profiling/task/network/analyze/layer7/protocols/http1/reader/reader.go
@@ -36,9 +36,11 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
+const methodConnect = "CONNECT"
+
 var (
 	requestMethods = []string{
-		"GET", "POST", "OPTIONS", "HEAD", "PUT", "DELETE", "CONNECT", "TRACE", "PATCH",
+		"GET", "POST", "OPTIONS", "HEAD", "PUT", "DELETE", methodConnect, "TRACE", "PATCH",
 	}
 	pooledReader = sync.Pool{
 		New: func() any {

--- a/pkg/profiling/task/network/analyze/layer7/protocols/http1/reader/request.go
+++ b/pkg/profiling/task/network/analyze/layer7/protocols/http1/reader/request.go
@@ -104,7 +104,7 @@ func (r *Reader) ReadRequest(buf *buffer.Buffer, readBody bool) (*Request, enums
 	if !ok {
 		return nil, enums.ParseResultSkipPackage, fmt.Errorf("the protocol version cannot be identity: %s", proto)
 	}
-	justAuthority := req.Method == "CONNECT" && !strings.HasPrefix(requestURI, "/")
+	justAuthority := req.Method == methodConnect && !strings.HasPrefix(requestURI, "/")
 	if justAuthority {
 		requestURI = "http://" + requestURI
 	}

--- a/pkg/tools/profiling/kernel.go
+++ b/pkg/tools/profiling/kernel.go
@@ -28,6 +28,8 @@ import (
 	"github.com/apache/skywalking-rover/pkg/tools/host"
 )
 
+const kernelModuleName = "kernel"
+
 type KernelFinder struct {
 	kernelFileExists bool
 }
@@ -68,7 +70,7 @@ func (k *KernelFinder) Analyze(filepath string) (*Info, error) {
 	}
 
 	kernelModule := &Module{
-		Name:    "kernel",
+		Name:    kernelModuleName,
 		Symbols: symbols,
 		// kernel module could handling all symbols
 		Ranges: []*ModuleRange{
@@ -80,6 +82,6 @@ func (k *KernelFinder) Analyze(filepath string) (*Info, error) {
 	}
 
 	return NewInfo(map[string]*Module{
-		"kernel": kernelModule,
+		kernelModuleName: kernelModule,
 	}), nil
 }

--- a/scripts/build/lint.mk
+++ b/scripts/build/lint.mk
@@ -19,7 +19,7 @@
 GO_LINT = $(GO_PATH)/bin/golangci-lint
 
 linter:
-	$(GO_LINT) version || curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_PATH)/bin v2.4.0
+	$(GO_LINT) version || curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_PATH)/bin v2.12.2
 
 .PHONY: lint
 lint: linter generate

--- a/scripts/build/lint.mk
+++ b/scripts/build/lint.mk
@@ -19,7 +19,7 @@
 GO_LINT = $(GO_PATH)/bin/golangci-lint
 
 linter:
-	$(GO_LINT) version || curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_PATH)/bin v2.12.2
+	$(GO_LINT) version || curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b $(GO_PATH)/bin v2.12.2
 
 .PHONY: lint
 lint: linter generate


### PR DESCRIPTION
## Summary

Bump the Go toolchain from 1.25 to 1.26.

- `go.mod`: `go 1.25` → `go 1.26`
- `docker/Dockerfile.base`: `golang:1.25` → `golang:1.26`
- `.github/workflows/rover.yaml`: `go-version` `1.25` → `1.26`
- `.github/workflows/compatibility.yaml`: `go-version` `1.25` → `1.26`

## Test Plan

- `go mod verify` passes
- CI builds with Go 1.26