### PR TITLE
Reduce eBPF verifier complexity by converting hot inline helpers to BPF-to-BPF calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Release Notes.
 * Bump up go version to `1.24` and eBPF library to `0.18.0`.
 * Support detect ztunnel environment in the inbound request.
 * Increase the transmit buffer size in the network profiling and access log module.
+* Reduce eBPF verifier complexity by converting hot inline helpers to BPF-to-BPF calls, fixing the "program too large" failure when loading access log programs on newer kernels.
 
 #### Bug Fixes
 * Fix the base image cannot run in the arm64.

--- a/bpf/accesslog/common/connection.h
+++ b/bpf/accesslog/common/connection.h
@@ -285,7 +285,7 @@ static __always_inline void submit_new_connection(void* ctx, bool success, __u32
     bpf_map_update_elem(&active_connection_map, &conid, &con, 0);
 }
 
-static __inline struct active_connection_t* get_or_create_active_conn(void *ctx, __u32 tgid, __u32 fd, __u32 func_name, __u8 role) {
+static __noinline struct active_connection_t* get_or_create_active_conn(void *ctx, __u32 tgid, __u32 fd, __u32 func_name, __u8 role) {
     __u64 conid = gen_tgid_fd(tgid, fd);
     struct active_connection_t *conn = bpf_map_lookup_elem(&active_connection_map, &conid);
     if (conn != NULL) {

--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -28,6 +28,16 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
 
+// Force a function to be emitted as a real BPF-to-BPF call instead of being
+// inlined. The verifier checks a non-inlined sub-program only once, instead of
+// re-verifying every inlined copy on every code path, which dramatically lowers
+// the processed-instruction count for large programs (avoids the
+// "BPF program is too large" / 1M instruction limit). BPF-to-BPF calls require
+// kernel >= 4.16, which the network / access-log data path already mandates.
+#ifndef __noinline
+#define __noinline __attribute__((noinline))
+#endif
+
 // Define types commonly needed but not in BPF headers
 typedef __s64 ssize_t;
 typedef __s8 int8_t;

--- a/bpf/include/protocol_analyzer.h
+++ b/bpf/include/protocol_analyzer.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "api.h"
+
 #define CONNECTION_PROTOCOL_UNKNOWN 0
 #define CONNECTION_PROTOCOL_HTTP1 1
 #define CONNECTION_PROTOCOL_HTTP2 2

--- a/bpf/include/protocol_analyzer.h
+++ b/bpf/include/protocol_analyzer.h
@@ -178,7 +178,7 @@ static __inline __u32 infer_http2_message(const char* buf, size_t count) {
 	return CONNECTION_MESSAGE_TYPE_UNKNOWN;
 }
 
-static __inline __u32 analyze_protocol(char *buf, __u32 count, __u8 *protocol_ref) {
+static __noinline __u32 analyze_protocol(char *buf, __u32 count, __u8 *protocol_ref) {
     __u32 protocol = CONNECTION_PROTOCOL_UNKNOWN, type = CONNECTION_MESSAGE_TYPE_UNKNOWN;
 
     // support http 1.x and 2.x

--- a/bpf/include/socket_data.h
+++ b/bpf/include/socket_data.h
@@ -142,7 +142,7 @@ static __always_inline void __upload_socket_data_with_buffer(void *ctx, __u8 ind
     rover_submit_buf(ctx, &socket_data_upload_queue, socket_data_event, sizeof(*socket_data_event));
 }
 
-static __always_inline void upload_socket_data_buf(void *ctx, char* buf, ssize_t size, struct upload_data_args *args, __u8 force_unfinished) {
+static __noinline void upload_socket_data_buf(void *ctx, char* buf, ssize_t size, struct upload_data_args *args, __u8 force_unfinished) {
     ssize_t already_send = 0;
 #pragma unroll
     for (__u8 index = 0; index < SOCKET_UPLOAD_CHUNK_LIMIT; index++) {
@@ -195,7 +195,7 @@ if (iov_index < iovlen) {                                                   \
     loop_count++;                                                                                                                    \
 }
 
-static __always_inline void upload_socket_data_iov(void *ctx, struct iovec* iov, const size_t iovlen, ssize_t size, struct upload_data_args *args) {
+static __noinline void upload_socket_data_iov(void *ctx, struct iovec* iov, const size_t iovlen, ssize_t size, struct upload_data_args *args) {
     ssize_t already_send = 0;
     ssize_t cur_iov_sended = 0;
     __u8 iov_index = 0;

--- a/bpf/include/socket_reader.h
+++ b/bpf/include/socket_reader.h
@@ -30,7 +30,7 @@ struct {
     __uint(max_entries, 1);
 } socket_buffer_reader_map SEC(".maps");
 
-static __inline struct socket_buffer_reader_t* read_socket_data(char* buf, struct iovec *iovec, __u32 bytes_count) {
+static __noinline struct socket_buffer_reader_t* read_socket_data(char* buf, struct iovec *iovec, __u32 bytes_count) {
     __u64 size = 0;
     __u32 kZero = 0;
     char* data_buf;

--- a/bpf/include/socket_reader.h
+++ b/bpf/include/socket_reader.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "api.h"
 #include "socket_opts.h"
 
 struct socket_buffer_reader_t {


### PR DESCRIPTION
## Problem

On newer kernels (reproduced on GKE COS `6.12` / amd64), the access log module fails to start and the pod enters `CrashLoopBackOff`:

```
Error: start module access_log failure: field GoTlsReadRet: program go_tls_read_ret:
load program: argument list too long: 2367: (b7) r1 = 2048:
BPF program is too large. Processed 1000001 insn (truncated, 449 line(s) omitted)
```

Despite the `argument list too long` wording, this is **not** an arguments problem — it is the eBPF **verifier complexity limit**. The verifier processed more than 1,000,000 instructions (`Processed 1000001 insn`) without converging and rejected the program.

## Root cause

`go_tls_read_ret` fully `__always_inline`-expands the entire data path into a single program:

- `process_write_data`
  - → `read_socket_data` + `analyze_protocol` (HTTP/2 inference with nested unrolled loops)
  - → `get_or_create_active_conn`
  - → `upload_socket_data` → `upload_socket_data_buf` (6× unrolled) **and** `upload_socket_data_iov` (6× unrolled), each inlining `__upload_socket_data_with_buffer`

The verifier explores both the buf and iov branches × 6 chunks × per-chunk branches, multiplied by the protocol-analysis branches. This produces a combinatorial path explosion. `go_tls` trips the limit first because it carries the extra arch-specific `get_goid` / `go_regabi_regs` register reads on top of the shared path; the other SSL probes (`openssl`, `node_tls`) walk the same data path and are next in line.

## Fix

Convert the heaviest **shared** inline helpers on the data path into **BPF-to-BPF sub-program calls** (`__noinline`). A non-inlined sub-program is verified **once** instead of being re-verified for every inlined copy on every code path, which sharply lowers the processed-instruction count.

Functions converted (all ≤ 5 args, so they fit the BPF calling convention with no signature changes):

| File | Function |
|------|----------|
| `bpf/include/api.h` | new `__noinline` macro (guarded with `#ifndef`) |
| `bpf/include/socket_data.h` | `upload_socket_data_buf`, `upload_socket_data_iov` |
| `bpf/include/protocol_analyzer.h` | `analyze_protocol` |
| `bpf/include/socket_reader.h` | `read_socket_data` |
| `bpf/accesslog/common/connection.h` | `get_or_create_active_conn` |

Because these live in shared headers, every program on the data path benefits at once (`go_tls`, `openssl`, `node_tls`, syscall transfer).

This is purely an inlining-strategy change — **no maps, structs, or upload semantics are modified**, so runtime behavior is unchanged.

## Compatibility

BPF-to-BPF calls require kernel **≥ 4.16**. The access log / network monitoring path already requires 4.16+ (see `docs/en/setup/overview.md`), so the supported-kernel matrix is unchanged.

## Verification

Built the amd64 object and loaded `go_tls_read_ret` through the real kernel verifier on amd64 (kernel `6.1`, same architecture and verifier generation as the failing GKE node):

| Build | Processed insns | Result |
|-------|----------------:|--------|
| Before (original GKE error, amd64 / 6.12) | 1,000,001 | ❌ rejected (> 1M limit) |
| After (this PR, amd64 / 6.1)              |   178,670 | ✅ verified |

The program now verifies at roughly 1/6 of the instruction limit.